### PR TITLE
Add merge request operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ The GitLab Extended node supports the following operations:
 - Pipelines: create, get, and list
 - Files: get and list
 - Issues: create and get
+- Merge Requests: create, get, and list
 - Raw API requests
 
 


### PR DESCRIPTION
## Summary
- extend GitLab node with merge request support
- document merge request operations in README

## Testing
- `npm run lint`
- `npm test`
