### PR TITLE
Add configurable GitLab API URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ The GitLab Extended node supports the following operations:
 
 Authentication can be configured using either a personal access token or OAuth2. Create the appropriate GitLab credentials in n8n and select them in the node.
 
+Use the <code>API URL</code> field to specify your GitLab instance's API base address, for example <code>https://gitlab.your-company.com/api/v4</code>.
+
 ## Compatibility
 
 This package requires n8n version 1.0.0 or later and is tested on Node.js 20.

--- a/nodes/GitlabExtended/GenericFunctions.ts
+++ b/nodes/GitlabExtended/GenericFunctions.ts
@@ -37,15 +37,16 @@ export async function gitlabApiRequest(
     }
 
     const authenticationMethod = this.getNodeParameter('authentication', 0);
+    const baseUrl = (this.getNodeParameter('apiUrl', 0) as string).replace(/\/$/, '');
 
     try {
         if (authenticationMethod === 'accessToken') {
-            const credentials = await this.getCredentials('gitlabApi');
-            options.uri = `${(credentials.server as string).replace(/\/$/, '')}/api/v4${endpoint}`;
+            await this.getCredentials('gitlabApi');
+            options.uri = `${baseUrl}${endpoint}`;
             return await this.helpers.requestWithAuthentication.call(this, 'gitlabApi', options);
         } else {
-            const credentials = await this.getCredentials('gitlabOAuth2Api');
-            options.uri = `${(credentials.server as string).replace(/\/$/, '')}/api/v4${endpoint}`;
+            await this.getCredentials('gitlabOAuth2Api');
+            options.uri = `${baseUrl}${endpoint}`;
             return await this.helpers.requestOAuth2.call(this, 'gitlabOAuth2Api', options);
         }
     } catch (error) {

--- a/nodes/GitlabExtended/GitlabExtended.node.ts
+++ b/nodes/GitlabExtended/GitlabExtended.node.ts
@@ -45,6 +45,13 @@ export class GitlabExtended implements INodeType {
                 default: 'accessToken',
             },
             {
+                displayName: 'API URL',
+                name: 'apiUrl',
+                type: 'string',
+                default: 'https://gitlab.com/api/v4',
+                description: 'Base URL of your GitLab API including the API path',
+            },
+            {
                 displayName: 'Resource',
                 name: 'resource',
                 type: 'options',


### PR DESCRIPTION
## Summary
- allow setting a custom `apiUrl` in GitLab node
- build request URLs using the new field
- document API URL option in README

## Testing
- `npm test`