### PR TITLE
Update host param for GitLab API

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The GitLab Extended node supports the following operations:
 
 Authentication can be configured using either a personal access token or OAuth2. Create the appropriate GitLab credentials in n8n and select them in the node.
 
-Use the <code>API URL</code> field to specify your GitLab instance's API base address, for example <code>https://gitlab.your-company.com/api/v4</code>.
+Use the <code>Host</code> field to specify your GitLab instance's host address, for example <code>https://gitlab.your-company.com</code>. Requests automatically use the <code>/api/v4</code> path.
 
 ## Compatibility
 

--- a/nodes/GitlabExtended/GenericFunctions.ts
+++ b/nodes/GitlabExtended/GenericFunctions.ts
@@ -37,7 +37,8 @@ export async function gitlabApiRequest(
     }
 
     const authenticationMethod = this.getNodeParameter('authentication', 0);
-    const baseUrl = (this.getNodeParameter('apiUrl', 0) as string).replace(/\/$/, '');
+    const host = (this.getNodeParameter('host', 0) as string).replace(/\/$/, '');
+    const baseUrl = `${host}/api/v4`;
 
     try {
         if (authenticationMethod === 'accessToken') {

--- a/nodes/GitlabExtended/GitlabExtended.node.ts
+++ b/nodes/GitlabExtended/GitlabExtended.node.ts
@@ -45,11 +45,11 @@ export class GitlabExtended implements INodeType {
                 default: 'accessToken',
             },
             {
-                displayName: 'API URL',
-                name: 'apiUrl',
+                displayName: 'Host',
+                name: 'host',
                 type: 'string',
-                default: 'https://gitlab.com/api/v4',
-                description: 'Base URL of your GitLab API including the API path',
+                default: 'https://gitlab.com',
+                description: 'Base URL of your GitLab host. The path "/api/v4" is appended automatically.',
             },
             {
                 displayName: 'Resource',


### PR DESCRIPTION
## Summary
- rename `apiUrl` parameter to `host`
- append `/api/v4` automatically when sending requests
- update README for new host parameter

## Testing
- `npm test`