### PR TITLE
Add Gitlab Extended API credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ The GitLab Extended node supports the following operations:
 - Merge Requests: create, get, and list
 - Raw API requests
 
-
 ## Credentials
 
-Authentication can be configured using either a personal access token or OAuth2. Create the appropriate GitLab credentials in n8n and select them in the node.
+Authentication can be configured using either a personal access token or OAuth2. Create the appropriate GitLab credentials in n8n and select them in the node.  
+The package also exposes <code>Gitlab Extended API</code> credentials which let you store your GitLab server, access token and default project details in one place.
 
 Use the <code>Host</code> field to specify your GitLab instance's host address, for example <code>https://gitlab.your-company.com</code>. Requests automatically use the <code>/api/v4</code> path.
 

--- a/credentials/GitlabExtendedApi.credentials.ts
+++ b/credentials/GitlabExtendedApi.credentials.ts
@@ -1,0 +1,64 @@
+import type {
+	IAuthenticateGeneric,
+	ICredentialTestRequest,
+	ICredentialType,
+	INodeProperties,
+} from 'n8n-workflow';
+
+export class GitlabExtendedApi implements ICredentialType {
+	name = 'gitlabExtendedApi';
+
+	displayName = 'Gitlab Extended API';
+
+	documentationUrl = 'gitlab';
+
+	properties: INodeProperties[] = [
+		{
+			displayName: 'Gitlab Server',
+			name: 'server',
+			type: 'string',
+			default: 'https://gitlab.com',
+		},
+		{
+			displayName: 'Access Token',
+			name: 'accessToken',
+			type: 'string',
+			typeOptions: { password: true },
+			default: '',
+		},
+		{
+			displayName: 'Project owner',
+			name: 'projectOwner',
+			type: 'string',
+			default: '',
+		},
+		{
+			displayName: 'Project name',
+			name: 'projectName',
+			type: 'string',
+			default: '',
+		},
+		{
+			displayName: 'Project ID',
+			name: 'projectId',
+			type: 'number',
+			default: 0,
+		},
+	];
+
+	authenticate: IAuthenticateGeneric = {
+		type: 'generic',
+		properties: {
+			headers: {
+				'Private-Token': '={{$credentials.accessToken}}',
+			},
+		},
+	};
+
+	test: ICredentialTestRequest = {
+		request: {
+			baseURL: '={{$credentials.server.replace(new RegExp("/$"), "") + "/api/v4" }}',
+			url: '/personal_access_tokens/self',
+		},
+	};
+}

--- a/index.ts
+++ b/index.ts
@@ -1,3 +1,5 @@
 import { GitlabExtended } from './nodes/GitlabExtended/GitlabExtended.node';
+import { GitlabExtendedApi } from './credentials/GitlabExtendedApi.credentials';
 
 export const nodes = [GitlabExtended];
+export const credentials = [GitlabExtendedApi];

--- a/package.json
+++ b/package.json
@@ -34,7 +34,9 @@
   ],
   "n8n": {
     "n8nNodesApiVersion": 1,
-    "credentials": [],
+    "credentials": [
+      "dist/credentials/GitlabExtendedApi.credentials.js"
+    ],
     "nodes": [
       "dist/nodes/GitlabExtended/GitlabExtended.node.js"
     ]

--- a/tests/gitlabExtendedApiCredentials.test.js
+++ b/tests/gitlabExtendedApiCredentials.test.js
@@ -1,0 +1,16 @@
+import assert from 'node:assert';
+import test from 'node:test';
+import { GitlabExtendedApi } from '../dist/credentials/GitlabExtendedApi.credentials.js';
+
+test('Gitlab Extended API credentials expose expected fields', () => {
+	const cred = new GitlabExtendedApi();
+	assert.strictEqual(cred.name, 'gitlabExtendedApi');
+	const names = cred.properties.map((p) => p.name);
+	assert.deepStrictEqual(names, [
+		'server',
+		'accessToken',
+		'projectOwner',
+		'projectName',
+		'projectId',
+	]);
+});


### PR DESCRIPTION
## Summary
- add new `GitlabExtendedApi` credential type
- expose credential in package `index.ts` and package.json
- document `Gitlab Extended API` credentials in README
- test that new credential exposes expected fields

## Testing
- `npm run format`
- `npm run lint`
- `npm test`
