### PR TITLE
Use GitlabExtendedApi credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,9 @@ The GitLab Extended node supports the following operations:
 
 ## Credentials
 
-Authentication can be configured using either a personal access token or OAuth2. Create the appropriate GitLab credentials in n8n and select them in the node.  
-The package also exposes <code>Gitlab Extended API</code> credentials which let you store your GitLab server, access token and default project details in one place.
+Authentication is handled exclusively via the <code>Gitlab Extended API</code> credentials. Create these credentials in n8n to store your GitLab server, access token and default project details in one place.
 
-Use the <code>Host</code> field to specify your GitLab instance's host address, for example <code>https://gitlab.your-company.com</code>. Requests automatically use the <code>/api/v4</code> path.
+The credentials' <code>server</code> field specifies your GitLab instance host (e.g. <code>https://gitlab.your-company.com</code>). Requests automatically use the <code>/api/v4</code> path.
 
 ## Compatibility
 

--- a/nodes/GitlabExtended/GenericFunctions.ts
+++ b/nodes/GitlabExtended/GenericFunctions.ts
@@ -36,20 +36,17 @@ export async function gitlabApiRequest(
         delete options.qs;
     }
 
-    const authenticationMethod = this.getNodeParameter('authentication', 0);
-    const host = (this.getNodeParameter('host', 0) as string).replace(/\/$/, '');
+    const credential = await this.getCredentials('gitlabExtendedApi');
+    const host = (credential.server as string).replace(/\/$/, '');
     const baseUrl = `${host}/api/v4`;
 
     try {
-        if (authenticationMethod === 'accessToken') {
-            await this.getCredentials('gitlabApi');
-            options.uri = `${baseUrl}${endpoint}`;
-            return await this.helpers.requestWithAuthentication.call(this, 'gitlabApi', options);
-        } else {
-            await this.getCredentials('gitlabOAuth2Api');
-            options.uri = `${baseUrl}${endpoint}`;
-            return await this.helpers.requestOAuth2.call(this, 'gitlabOAuth2Api', options);
-        }
+        options.uri = `${baseUrl}${endpoint}`;
+        return await this.helpers.requestWithAuthentication.call(
+            this,
+            'gitlabExtendedApi',
+            options,
+        );
     } catch (error) {
         throw new NodeApiError(this.getNode(), error as JsonObject);
     }

--- a/nodes/GitlabExtended/GitlabExtended.node.ts
+++ b/nodes/GitlabExtended/GitlabExtended.node.ts
@@ -23,34 +23,11 @@ export class GitlabExtended implements INodeType {
         outputs: [NodeConnectionType.Main],
         credentials: [
             {
-                name: 'gitlabApi',
+                name: 'gitlabExtendedApi',
                 required: true,
-                displayOptions: { show: { authentication: ['accessToken'] } },
-            },
-            {
-                name: 'gitlabOAuth2Api',
-                required: true,
-                displayOptions: { show: { authentication: ['oAuth2'] } },
             },
         ],
         properties: [
-            {
-                displayName: 'Authentication',
-                name: 'authentication',
-                type: 'options',
-                options: [
-                    { name: 'Access Token', value: 'accessToken' },
-                    { name: 'OAuth2', value: 'oAuth2' },
-                ],
-                default: 'accessToken',
-            },
-            {
-                displayName: 'Host',
-                name: 'host',
-                type: 'string',
-                default: 'https://gitlab.com',
-                description: 'Base URL of your GitLab host. The path "/api/v4" is appended automatically.',
-            },
             {
                 displayName: 'Resource',
                 name: 'resource',

--- a/tests/gitlabApiRequest.test.js
+++ b/tests/gitlabApiRequest.test.js
@@ -2,34 +2,22 @@ import assert from 'node:assert';
 import test from 'node:test';
 import { gitlabApiRequest } from '../dist/nodes/GitlabExtended/GenericFunctions.js';
 
-function mockContext({ authentication = 'accessToken', host = 'https://gitlab.example.com/' } = {}) {
-  const calls = { };
+function mockContext({ server = 'https://gitlab.example.com/' } = {}) {
+  const calls = {};
   return {
     calls,
-    getNodeParameter(name) {
-      if (name === 'authentication') return authentication;
-      if (name === 'host') return host;
-      throw new Error('Unexpected parameter ' + name);
+    getNodeParameter() {
+      throw new Error('Unexpected parameter');
     },
     async getCredentials(name) {
       calls.credentials = name;
-      if (name === 'gitlabApi') {
-        return { accessToken: 'mockAccessToken' };
-      }
-      if (name === 'gitlabOAuth2Api') {
-        return { clientId: 'mockClientId', clientSecret: 'mockClientSecret', accessToken: 'mockOAuth2Token' };
+      if (name === 'gitlabExtendedApi') {
+        return { accessToken: 'mockToken', server };
       }
       throw new Error('Unexpected credentials name: ' + name);
     },
     helpers: {
       async requestWithAuthentication(name, options) {
-        calls.method = 'token';
-        calls.name = name;
-        calls.options = options;
-        return { ok: true };
-      },
-      async requestOAuth2(name, options) {
-        calls.method = 'oauth2';
         calls.name = name;
         calls.options = options;
         return { ok: true };
@@ -41,27 +29,17 @@ function mockContext({ authentication = 'accessToken', host = 'https://gitlab.ex
   };
 }
 
-test('uses access token authentication and builds correct URL', async () => {
-  const ctx = mockContext({ authentication: 'accessToken', host: 'https://gitlab.example.com/' });
+test('uses Gitlab Extended credentials and builds correct URL', async () => {
+  const ctx = mockContext({ server: 'https://gitlab.example.com/' });
   const result = await gitlabApiRequest.call(ctx, 'GET', '/projects', {}, undefined);
-  assert.strictEqual(ctx.calls.method, 'token');
-  assert.strictEqual(ctx.calls.name, 'gitlabApi');
+  assert.strictEqual(ctx.calls.name, 'gitlabExtendedApi');
   assert.strictEqual(ctx.calls.options.uri, 'https://gitlab.example.com/api/v4/projects');
   assert.deepStrictEqual(result, { ok: true });
 });
 
-test('uses OAuth2 authentication and trims trailing slash', async () => {
-  const ctx = mockContext({ authentication: 'oAuth2', host: 'https://gitlab.example.com/' });
-  const result = await gitlabApiRequest.call(ctx, 'GET', '/foo', {}, undefined);
-  assert.strictEqual(ctx.calls.method, 'oauth2');
-  assert.strictEqual(ctx.calls.name, 'gitlabOAuth2Api');
-  assert.strictEqual(ctx.calls.options.uri, 'https://gitlab.example.com/api/v4/foo');
-  assert.deepStrictEqual(result, { ok: true });
-});
 
-
-test('builds URL correctly when host lacks trailing slash', async () => {
-  const ctx = mockContext({ authentication: 'accessToken', host: 'https://gitlab.example.com' });
+test('builds URL correctly when server lacks trailing slash', async () => {
+  const ctx = mockContext({ server: 'https://gitlab.example.com' });
   await gitlabApiRequest.call(ctx, 'GET', '/bar', {}, undefined);
   assert.strictEqual(ctx.calls.options.uri, 'https://gitlab.example.com/api/v4/bar');
 });


### PR DESCRIPTION
## Summary
- use Gitlab Extended API credentials for all requests
- remove authentication/host options from the node
- update docs and tests

## Testing
- `npm test`