### PR TITLE
Remove project parameters from node

### DIFF
--- a/nodes/GitlabExtended/GitlabExtended.node.ts
+++ b/nodes/GitlabExtended/GitlabExtended.node.ts
@@ -120,8 +120,6 @@ export class GitlabExtended implements INodeType {
                 ],
                 default: 'request',
             },
-            { displayName: 'Project Owner', name: 'owner', type: 'string', required: true, default: '' },
-            { displayName: 'Project Name', name: 'repository', type: 'string', required: true, default: '' },
             {
                 displayName: 'Branch Name',
                 name: 'branchName',
@@ -341,8 +339,9 @@ export class GitlabExtended implements INodeType {
             let body: IDataObject = {};
             let qs: IDataObject = {};
             let returnAll = false;
-            const owner = encodeURIComponent(this.getNodeParameter('owner', i) as string);
-            const repo = encodeURIComponent(this.getNodeParameter('repository', i) as string);
+            const credential = await this.getCredentials('gitlabExtendedApi');
+            const owner = encodeURIComponent(credential.projectOwner as string);
+            const repo = encodeURIComponent(credential.projectName as string);
             const base = `/projects/${owner}%2F${repo}`;
 
             if (resource === 'branch') {

--- a/tests/gitlabEncoding.test.js
+++ b/tests/gitlabEncoding.test.js
@@ -1,18 +1,8 @@
 import assert from 'node:assert';
 import test from 'node:test';
-import { GitlabExtended } from '../dist/nodes/GitlabExtended/GitlabExtended.node.js';
-
 function computeBase(ownerValue, repoValue) {
-  const node = new GitlabExtended();
-  const ctx = {
-    getNodeParameter(name) {
-      if (name === 'owner') return ownerValue;
-      if (name === 'repository') return repoValue;
-      throw new Error('Unexpected parameter ' + name);
-    },
-  };
-  const owner = encodeURIComponent(ctx.getNodeParameter('owner'));
-  const repo = encodeURIComponent(ctx.getNodeParameter('repository'));
+  const owner = encodeURIComponent(ownerValue);
+  const repo = encodeURIComponent(repoValue);
   return `/projects/${owner}%2F${repo}`;
 }
 


### PR DESCRIPTION
## Summary
- use Gitlab Extended API credentials for project info
- drop Project Owner and Project Name fields
- simplify encoding tests

## Testing
- `npm test`