### PR TITLE
Fix base path with project ID

### DIFF
--- a/nodes/GitlabExtended/GitlabExtended.node.ts
+++ b/nodes/GitlabExtended/GitlabExtended.node.ts
@@ -340,9 +340,9 @@ export class GitlabExtended implements INodeType {
             let qs: IDataObject = {};
             let returnAll = false;
             const credential = await this.getCredentials('gitlabExtendedApi');
-            const owner = encodeURIComponent(credential.projectOwner as string);
-            const repo = encodeURIComponent(credential.projectName as string);
-            const base = `/projects/${owner}%2F${repo}`;
+            const base = credential.projectId
+                ? `/projects/${credential.projectId}`
+                : `/projects/${encodeURIComponent(credential.projectOwner as string)}%2F${encodeURIComponent(credential.projectName as string)}`;
 
             if (resource === 'branch') {
                 if (operation === 'create') {

--- a/tests/gitlabEncoding.test.js
+++ b/tests/gitlabEncoding.test.js
@@ -1,6 +1,9 @@
 import assert from 'node:assert';
 import test from 'node:test';
-function computeBase(ownerValue, repoValue) {
+function computeBase(ownerValue, repoValue, projectId) {
+  if (projectId) {
+    return `/projects/${projectId}`;
+  }
   const owner = encodeURIComponent(ownerValue);
   const repo = encodeURIComponent(repoValue);
   return `/projects/${owner}%2F${repo}`;
@@ -29,4 +32,9 @@ test('encodes slashes in repository', () => {
 test('encodes slashes and spaces in both parts', () => {
   const base = computeBase('group/sub name', 'repo/with space');
   assert.strictEqual(base, '/projects/group%2Fsub%20name%2Frepo%2Fwith%20space');
+});
+
+test('uses project ID when provided', () => {
+  const base = computeBase('ignored', 'ignored', 123);
+  assert.strictEqual(base, '/projects/123');
 });


### PR DESCRIPTION
## Summary
- allow credentials `projectId` to define API base path
- test encoding logic with project ID

## Testing
- `npm run build`
- `npm test`
