### PR TITLE
Add AI tool support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,17 @@ The credentials' <code>server</code> field specifies your GitLab instance host (
 
 This package requires n8n version 1.0.0 or later and is tested on Node.js 20.
 
+## Tool usage for AI
+
+The node is marked with `usableAsTool: true`, so it can be invoked by n8n's AI
+features. After installing the package and creating the **Gitlab Extended API**
+credentials, the node appears in the list of available tools when building
+generative AI workflows. An AI agent can call any of the supported operations—
+such as fetching files or creating issues—by providing the necessary
+parameters in natural language. The node runs using the credentials you
+configured, enabling automated access to your GitLab projects from AI-driven
+flows.
+
 ## Resources
 
 - [n8n community nodes documentation](https://docs.n8n.io/integrations/#community-nodes)

--- a/nodes/GitlabExtended/GitlabExtended.node.ts
+++ b/nodes/GitlabExtended/GitlabExtended.node.ts
@@ -19,6 +19,7 @@ export class GitlabExtended implements INodeType {
         version: 1,
         description: 'Extended GitLab node',
         defaults: { name: 'GitLab Extended' },
+        usableAsTool: true,
         inputs: [NodeConnectionType.Main],
         outputs: [NodeConnectionType.Main],
         credentials: [


### PR DESCRIPTION
## Summary
- allow Gitlab Extended node to be used as a tool
- document how to use the node as an AI tool

## Testing
- `npm test`