### PR TITLE
Fix discussionId requirement

### DIFF
--- a/nodes/GitlabExtended/GitlabExtended.node.ts
+++ b/nodes/GitlabExtended/GitlabExtended.node.ts
@@ -308,6 +308,7 @@ export class GitlabExtended implements INodeType {
 				displayName: 'Discussion ID',
 				name: 'discussionId',
 				type: 'string',
+				required: true,
 				displayOptions: {
 					show: {
 						resource: ['mergeRequest'],
@@ -636,6 +637,12 @@ export class GitlabExtended implements INodeType {
 						endpoint = `${base}/merge_requests/${iid}/discussions`;
 					} else {
 						const discussionId = this.getNodeParameter('discussionId', i);
+						if (!discussionId) {
+							throw new NodeOperationError(
+								this.getNode(),
+								'Discussion ID must be provided when replying to a discussion.',
+							);
+						}
 						endpoint = `${base}/merge_requests/${iid}/discussions/${discussionId}/notes`;
 					}
 				} else if (operation === 'updateNote') {

--- a/nodes/GitlabExtended/GitlabExtended.node.ts
+++ b/nodes/GitlabExtended/GitlabExtended.node.ts
@@ -637,6 +637,9 @@ export class GitlabExtended implements INodeType {
 						endpoint = `${base}/merge_requests/${iid}/discussions`;
 					} else {
 						const discussionId = this.getNodeParameter('discussionId', i);
+						// The discussionId parameter is marked as required in the UI configuration.
+						// This check is a defensive measure to handle cases where the parameter might
+						// still be missing due to API calls bypassing the UI or misconfiguration.
 						if (!discussionId) {
 							throw new NodeOperationError(
 								this.getNode(),


### PR DESCRIPTION
## Summary
- require a discussion ID when replying to an existing discussion
- validate that the ID is present at runtime

## Testing
- `npm run lint`
- `npm test`
