### PR TITLE
Fix release_type in Full Release workflow

### DIFF
--- a/.github/workflows/full-release.yml
+++ b/.github/workflows/full-release.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Bump package version
         id: bump_version
         env:
-          RELEASE_TYPE: ${{ github.event.inputs.release_type }}
+          RELEASE_TYPE: ${{ github.event.inputs.release_type || 'patch' }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config user.name "github-actions"

--- a/.github/workflows/full-release.yml
+++ b/.github/workflows/full-release.yml
@@ -30,14 +30,15 @@ jobs:
       - run: npm test
       - name: Bump package version
         id: bump_version
+        env:
+          RELEASE_TYPE: ${{ github.event.inputs.release_type }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"
-          new_version=$(npm version patch -m "chore(release): %s [skip ci]")
+          new_version=$(npm version "$RELEASE_TYPE" -m "chore(release): %s [skip ci]")
           echo "version=$new_version" >> "$GITHUB_OUTPUT"
           git push --follow-tags
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1
         with:

--- a/.github/workflows/full-release.yml
+++ b/.github/workflows/full-release.yml
@@ -36,6 +36,10 @@ jobs:
         run: |
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"
+          if [[ "$RELEASE_TYPE" != "patch" && "$RELEASE_TYPE" != "minor" && "$RELEASE_TYPE" != "major" ]]; then
+            echo "Error: Invalid RELEASE_TYPE '$RELEASE_TYPE'. Allowed values are 'patch', 'minor', 'major'." >&2
+            exit 1
+          fi
           new_version=$(npm version "$RELEASE_TYPE" -m "chore(release): %s [skip ci]")
           echo "version=$new_version" >> "$GITHUB_OUTPUT"
           git push --follow-tags

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,10 +21,15 @@ jobs:
           node-version: 20
           cache: 'npm'
       - name: Bump package version
+        env:
+          RELEASE_TYPE: ${{ github.event.inputs.release_type || 'patch' }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"
-          npm version patch -m "chore(release): %s [skip ci]"
+          if [[ "$RELEASE_TYPE" != "patch" && "$RELEASE_TYPE" != "minor" && "$RELEASE_TYPE" != "major" ]]; then
+            echo "Error: Invalid RELEASE_TYPE '$RELEASE_TYPE'. Allowed values are 'patch', 'minor', 'major'." >&2
+            exit 1
+          fi
+          npm version "$RELEASE_TYPE" -m "chore(release): %s [skip ci]"
           git push --follow-tags
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- use `github.event.inputs.release_type` when bumping the version in the Full Release workflow

## Testing
- `npm test`