### PR TITLE
Fix ESLint error by alphabetizing mergeRequest options

### DIFF
--- a/nodes/GitlabExtended/GitlabExtended.node.ts
+++ b/nodes/GitlabExtended/GitlabExtended.node.ts
@@ -110,23 +110,15 @@ export class GitlabExtended implements INodeType {
 				description:
 					"Choose an action on merge requests, such as 'create' to start a merge request",
 				options: [
+					{ name: 'Add Labels', value: 'addLabels', action: 'Add labels' },
 					{ name: 'Create', value: 'create', action: 'Create a merge request' },
 					{ name: 'Create Note', value: 'createNote', action: 'Create a note' },
 					{ name: 'Get', value: 'get', action: 'Get a merge request' },
 					{ name: 'Get Many', value: 'getAll', action: 'List merge requests' },
-					{
-						name: 'Post Discussion Note',
-						value: 'postDiscussionNote',
-						action: 'Post to discussion',
-					},
-					{
-						name: 'Resolve Discussion',
-						value: 'resolveDiscussion',
-						action: 'Resolve a discussion',
-					},
-					{ name: 'Update Note', value: 'updateNote', action: 'Update a note' },
-					{ name: 'Add Labels', value: 'addLabels', action: 'Add labels' },
+					 { name: 'Post Discussion Note', value: 'postDiscussionNote', action: 'Post to discussion' },
 					{ name: 'Remove Labels', value: 'removeLabels', action: 'Remove labels' },
+					{ name: 'Resolve Discussion', value: 'resolveDiscussion', action: 'Resolve a discussion' },
+					{ name: 'Update Note', value: 'updateNote', action: 'Update a note' },
 				],
 				default: 'create',
 			},


### PR DESCRIPTION
Alphabetize the options for the `Operation` parameter under the `mergeRequest` resource in `nodes/GitlabExtended/GitlabExtended.node.ts`.

* Reorder the `options` array to be in alphabetical order by the "name" property.
* Ensure the updated `options` array is placed in the `mergeRequest` resource's `Operation` parameter definition.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Xopoko/n8n-nodes-extended-gitlab/pull/35?shareId=75ef89d3-9bc1-418c-96a0-a904688a6080).