### PR TITLE
Add helper for merge request discussion lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,22 @@ To add labels to a merge request, use the `manageLabels` operation with the foll
 
 Example:
 
-```json
+````json
 {
   "operation": "manageLabels",
   "mergeRequestId": 123,
   "labelAction": "add",
   "labels": "bug,urgent"
 }
+
+### Example: Get Discussion by ID
+
+To fetch a specific merge request discussion, use the `getMergeRequestDiscussion` helper:
+
+```ts
+const discussion = await getMergeRequestDiscussion.call(ctx, 1234, '123abc');
+````
+
 ## Credentials
 
 Authentication is handled exclusively via the <code>Gitlab Extended API</code> credentials. Create these credentials in n8n to store your GitLab server, access token and default project details in one place.

--- a/README.md
+++ b/README.md
@@ -38,21 +38,13 @@ To add labels to a merge request, use the `manageLabels` operation with the foll
 
 Example:
 
-````json
+```json
 {
   "operation": "manageLabels",
   "mergeRequestId": 123,
   "labelAction": "add",
   "labels": "bug,urgent"
 }
-
-### Example: Get Discussion by ID
-
-To fetch a specific merge request discussion, use the `getMergeRequestDiscussion` helper:
-
-```ts
-const discussion = await getMergeRequestDiscussion.call(ctx, 1234, '123abc');
-````
 
 ## Credentials
 

--- a/nodes/GitlabExtended/GenericFunctions.ts
+++ b/nodes/GitlabExtended/GenericFunctions.ts
@@ -1,10 +1,10 @@
 import type {
-    IExecuteFunctions,
-    IHookFunctions,
-    IDataObject,
-    JsonObject,
-    IHttpRequestMethods,
-    IRequestOptions,
+	IExecuteFunctions,
+	IHookFunctions,
+	IDataObject,
+	JsonObject,
+	IHttpRequestMethods,
+	IRequestOptions,
 } from 'n8n-workflow';
 import { NodeApiError } from 'n8n-workflow';
 
@@ -13,65 +13,80 @@ import { NodeApiError } from 'n8n-workflow';
  *
  */
 export async function gitlabApiRequest(
-    this: IHookFunctions | IExecuteFunctions,
-    method: IHttpRequestMethods,
-    endpoint: string,
-    body: object,
-    query?: IDataObject,
-    option: IDataObject = {},
+	this: IHookFunctions | IExecuteFunctions,
+	method: IHttpRequestMethods,
+	endpoint: string,
+	body: object,
+	query?: IDataObject,
+	option: IDataObject = {},
 ): Promise<any> {
-    const options: IRequestOptions = {
-        method,
-        headers: {},
-        body,
-        qs: query,
-        uri: '',
-        json: true,
-    };
+	const options: IRequestOptions = {
+		method,
+		headers: {},
+		body,
+		qs: query,
+		uri: '',
+		json: true,
+	};
 
-    if (Object.keys(option).length !== 0) {
-        Object.assign(options, option);
-    }
-    if (query === undefined) {
-        delete options.qs;
-    }
+	if (Object.keys(option).length !== 0) {
+		Object.assign(options, option);
+	}
+	if (query === undefined) {
+		delete options.qs;
+	}
 
-    const credential = await this.getCredentials('gitlabExtendedApi');
-    const host = (credential.server as string).replace(/\/$/, '');
-    const baseUrl = `${host}/api/v4`;
+	const credential = await this.getCredentials('gitlabExtendedApi');
+	const host = (credential.server as string).replace(/\/$/, '');
+	const baseUrl = `${host}/api/v4`;
 
-    try {
-        options.uri = `${baseUrl}${endpoint}`;
-        return await this.helpers.requestWithAuthentication.call(
-            this,
-            'gitlabExtendedApi',
-            options,
-        );
-    } catch (error) {
-        throw new NodeApiError(this.getNode(), error as JsonObject);
-    }
+	try {
+		options.uri = `${baseUrl}${endpoint}`;
+		return await this.helpers.requestWithAuthentication.call(this, 'gitlabExtendedApi', options);
+	} catch (error) {
+		throw new NodeApiError(this.getNode(), error as JsonObject);
+	}
 }
 
 export async function gitlabApiRequestAllItems(
-    this: IHookFunctions | IExecuteFunctions,
-    method: IHttpRequestMethods,
-    endpoint: string,
-    body: any = {},
-    query: IDataObject = {},
+	this: IHookFunctions | IExecuteFunctions,
+	method: IHttpRequestMethods,
+	endpoint: string,
+	body: any = {},
+	query: IDataObject = {},
 ): Promise<any> {
-    const returnData: IDataObject[] = [];
+	const returnData: IDataObject[] = [];
 
-    let responseData;
+	let responseData;
 
-    query.per_page = 100;
-    query.page = 1;
+	query.per_page = 100;
+	query.page = 1;
 
-    do {
-        responseData = await gitlabApiRequest.call(this, method, endpoint, body as IDataObject, query, {
-            resolveWithFullResponse: true,
-        });
-        query.page++;
-        returnData.push.apply(returnData, responseData.body as IDataObject[]);
-    } while (responseData.headers.link?.includes('next'));
-    return returnData;
+	do {
+		responseData = await gitlabApiRequest.call(this, method, endpoint, body as IDataObject, query, {
+			resolveWithFullResponse: true,
+		});
+		query.page++;
+		returnData.push.apply(returnData, responseData.body as IDataObject[]);
+	} while (responseData.headers.link?.includes('next'));
+	return returnData;
+}
+
+/**
+ * Get a merge request discussion by ID
+ */
+export async function getMergeRequestDiscussion(
+	this: IHookFunctions | IExecuteFunctions,
+	mergeRequestIid: number,
+	discussionId: string,
+	query: IDataObject = {},
+): Promise<any> {
+	const credential = await this.getCredentials('gitlabExtendedApi');
+	const base = credential.projectId
+		? `/projects/${credential.projectId}`
+		: `/projects/${encodeURIComponent(credential.projectOwner as string)}%2F${encodeURIComponent(
+				credential.projectName as string,
+			)}`;
+	const endpoint = `${base}/merge_requests/${mergeRequestIid}/discussions/${discussionId}`;
+	return gitlabApiRequest.call(this, 'GET', endpoint, {}, query);
 }

--- a/tests/gitlabApiRequest.test.js
+++ b/tests/gitlabApiRequest.test.js
@@ -1,45 +1,62 @@
 import assert from 'node:assert';
 import test from 'node:test';
-import { gitlabApiRequest } from '../dist/nodes/GitlabExtended/GenericFunctions.js';
+import {
+	gitlabApiRequest,
+	getMergeRequestDiscussion,
+} from '../dist/nodes/GitlabExtended/GenericFunctions.js';
 
-function mockContext({ server = 'https://gitlab.example.com/' } = {}) {
-  const calls = {};
-  return {
-    calls,
-    getNodeParameter() {
-      throw new Error('Unexpected parameter');
-    },
-    async getCredentials(name) {
-      calls.credentials = name;
-      if (name === 'gitlabExtendedApi') {
-        return { accessToken: 'mockToken', server };
-      }
-      throw new Error('Unexpected credentials name: ' + name);
-    },
-    helpers: {
-      async requestWithAuthentication(name, options) {
-        calls.name = name;
-        calls.options = options;
-        return { ok: true };
-      },
-    },
-    getNode() {
-      return {};
-    },
-  };
+function mockContext({
+	server = 'https://gitlab.example.com/',
+	projectId = 0,
+	projectOwner = 'owner',
+	projectName = 'repo',
+} = {}) {
+	const calls = {};
+	return {
+		calls,
+		getNodeParameter() {
+			throw new Error('Unexpected parameter');
+		},
+		async getCredentials(name) {
+			calls.credentials = name;
+			if (name === 'gitlabExtendedApi') {
+				return { accessToken: 'mockToken', server, projectId, projectOwner, projectName };
+			}
+			throw new Error('Unexpected credentials name: ' + name);
+		},
+		helpers: {
+			async requestWithAuthentication(name, options) {
+				calls.name = name;
+				calls.options = options;
+				return { ok: true };
+			},
+		},
+		getNode() {
+			return {};
+		},
+	};
 }
 
 test('uses Gitlab Extended credentials and builds correct URL', async () => {
-  const ctx = mockContext({ server: 'https://gitlab.example.com/' });
-  const result = await gitlabApiRequest.call(ctx, 'GET', '/projects', {}, undefined);
-  assert.strictEqual(ctx.calls.name, 'gitlabExtendedApi');
-  assert.strictEqual(ctx.calls.options.uri, 'https://gitlab.example.com/api/v4/projects');
-  assert.deepStrictEqual(result, { ok: true });
+	const ctx = mockContext({ server: 'https://gitlab.example.com/' });
+	const result = await gitlabApiRequest.call(ctx, 'GET', '/projects', {}, undefined);
+	assert.strictEqual(ctx.calls.name, 'gitlabExtendedApi');
+	assert.strictEqual(ctx.calls.options.uri, 'https://gitlab.example.com/api/v4/projects');
+	assert.deepStrictEqual(result, { ok: true });
 });
 
-
 test('builds URL correctly when server lacks trailing slash', async () => {
-  const ctx = mockContext({ server: 'https://gitlab.example.com' });
-  await gitlabApiRequest.call(ctx, 'GET', '/bar', {}, undefined);
-  assert.strictEqual(ctx.calls.options.uri, 'https://gitlab.example.com/api/v4/bar');
+	const ctx = mockContext({ server: 'https://gitlab.example.com' });
+	await gitlabApiRequest.call(ctx, 'GET', '/bar', {}, undefined);
+	assert.strictEqual(ctx.calls.options.uri, 'https://gitlab.example.com/api/v4/bar');
+});
+
+test('getMergeRequestDiscussion builds correct endpoint', async () => {
+	const ctx = mockContext({ projectId: 1 });
+	const result = await getMergeRequestDiscussion.call(ctx, 1234, '123abc');
+	assert.strictEqual(
+		ctx.calls.options.uri,
+		'https://gitlab.example.com/api/v4/projects/1/merge_requests/1234/discussions/123abc',
+	);
+	assert.deepStrictEqual(result, { ok: true });
 });


### PR DESCRIPTION
## Summary
- add `getMergeRequestDiscussion` helper
- test discussion helper
- document example on how to fetch a discussion

## Testing
- `npm test`