### PR TITLE
Fix ref param visibility

### DIFF
--- a/nodes/GitlabExtended/GitlabExtended.node.ts
+++ b/nodes/GitlabExtended/GitlabExtended.node.ts
@@ -160,7 +160,7 @@ export class GitlabExtended implements INodeType {
                                 required: true,
                                 displayOptions: {
                                         show: {
-                                                resource: ['branch', 'pipeline', 'file'],
+                                                resource: ['branch', 'file'],
                                                 operation: ['create', 'get', 'list'],
                                         },
                                 },


### PR DESCRIPTION
## Summary
- hide `ref` parameter for pipeline operations

## Testing
- `npm run build`
- `npm test`
