### PR TITLE
Add pipeline cancel and retry operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ one of its operations.
 
 ### Pipeline
 * `create` – Trigger a pipeline
+* `retry` – Retry a pipeline
+* `cancel` – Cancel a pipeline
 * `get` – Get a pipeline by ID
 * `getAll` – List pipelines
-* `cancel` – Cancel a pipeline
-* `retry` – Retry a pipeline
 
 ### File
 * `get` – Retrieve a file

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ one of its operations.
 * `create` – Trigger a pipeline
 * `get` – Get a pipeline by ID
 * `getAll` – List pipelines
+* `cancel` – Cancel a pipeline
+* `retry` – Retry a pipeline
 
 ### File
 * `get` – Retrieve a file

--- a/nodes/GitlabExtended/GitlabExtended.node.ts
+++ b/nodes/GitlabExtended/GitlabExtended.node.ts
@@ -73,10 +73,10 @@ export class GitlabExtended implements INodeType {
                                displayOptions: { show: { resource: ['pipeline'] } },
                                description: "Select how to manage pipelines, like using 'get' to fetch pipeline details",
                                options: [
+                                       { name: 'Cancel', value: 'cancel', action: 'Cancel a pipeline' },
                                        { name: 'Create', value: 'create', action: 'Create a pipeline' },
                                        { name: 'Get', value: 'get', action: 'Get a pipeline' },
                                        { name: 'Get Many', value: 'getAll', action: 'List pipelines' },
-                                       { name: 'Cancel', value: 'cancel', action: 'Cancel a pipeline' },
                                        { name: 'Retry', value: 'retry', action: 'Retry a pipeline' },
                                ],
                                default: 'create',

--- a/nodes/GitlabExtended/GitlabExtended.node.ts
+++ b/nodes/GitlabExtended/GitlabExtended.node.ts
@@ -73,10 +73,10 @@ export class GitlabExtended implements INodeType {
                                displayOptions: { show: { resource: ['pipeline'] } },
                                description: "Select how to manage pipelines, like using 'get' to fetch pipeline details",
                                options: [
-                                       { name: 'Cancel', value: 'cancel', action: 'Cancel a pipeline' },
                                        { name: 'Create', value: 'create', action: 'Create a pipeline' },
                                        { name: 'Get', value: 'get', action: 'Get a pipeline' },
                                        { name: 'Get Many', value: 'getAll', action: 'List pipelines' },
+                                       { name: 'Cancel', value: 'cancel', action: 'Cancel a pipeline' },
                                        { name: 'Retry', value: 'retry', action: 'Retry a pipeline' },
                                ],
                                default: 'create',


### PR DESCRIPTION
## Summary
- extend pipeline operation options with Cancel and Retry
- update Pipeline ID parameter to show for the new operations
- support `/cancel` and `/retry` endpoints in execution logic
- document new operations in README

## Testing
- `npm test`