### PR TITLE
Add GitLab branch delete operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ one of its operations.
 * `create` – Create a branch
 * `get` – Get a branch
 * `getAll` – List branches
+* `delete` – Delete a branch
 
 ### Pipeline
 * `create` – Trigger a pipeline

--- a/nodes/GitlabExtended/GitlabExtended.node.ts
+++ b/nodes/GitlabExtended/GitlabExtended.node.ts
@@ -58,13 +58,14 @@ export class GitlabExtended implements INodeType {
 				displayOptions: { show: { resource: ['branch'] } },
 				description:
 					"Select how to manage branches; for example choose 'create' to add a new branch",
-				options: [
-					{ name: 'Create', value: 'create', action: 'Create a branch' },
-					{ name: 'Get', value: 'get', action: 'Get a branch' },
-					{ name: 'Get Many', value: 'getAll', action: 'List branches' },
-				],
-				default: 'create',
-			},
+                                options: [
+                                        { name: 'Create', value: 'create', action: 'Create a branch' },
+                                        { name: 'Get', value: 'get', action: 'Get a branch' },
+                                        { name: 'Get Many', value: 'getAll', action: 'List branches' },
+                                        { name: 'Delete', value: 'delete', action: 'Delete a branch' },
+                                ],
+                                default: 'create',
+                        },
 			{
                                displayName: 'Operation',
                                name: 'operation',
@@ -151,7 +152,7 @@ export class GitlabExtended implements INodeType {
                                 name: 'branch',
                                 type: 'string',
                                 required: true,
-                                displayOptions: { show: { resource: ['branch'], operation: ['create', 'get'] } },
+                                displayOptions: { show: { resource: ['branch'], operation: ['create', 'get', 'delete'] } },
                                 description: "Branch name, for example 'feature/login'",
 				default: '',
 			},
@@ -629,12 +630,16 @@ export class GitlabExtended implements INodeType {
 					requestMethod = 'GET';
                                         const branch = this.getNodeParameter('branch', i) as string;
 					endpoint = `${base}/repository/branches/${encodeURIComponent(branch)}`;
-				} else if (operation === 'getAll') {
-					requestMethod = 'GET';
-					returnAll = this.getNodeParameter('returnAll', i);
-					if (!returnAll) qs.per_page = this.getNodeParameter('limit', i);
-					endpoint = `${base}/repository/branches`;
-				}
+                                } else if (operation === 'getAll') {
+                                        requestMethod = 'GET';
+                                        returnAll = this.getNodeParameter('returnAll', i);
+                                        if (!returnAll) qs.per_page = this.getNodeParameter('limit', i);
+                                        endpoint = `${base}/repository/branches`;
+                                } else if (operation === 'delete') {
+                                        requestMethod = 'DELETE';
+                                        const branch = this.getNodeParameter('branch', i) as string;
+                                        endpoint = `${base}/repository/branches/${encodeURIComponent(branch)}`;
+                                }
 			} else if (resource === 'pipeline') {
                                 if (operation === 'create') {
                                         requestMethod = 'POST';

--- a/tests/gitlabApiRequest.test.js
+++ b/tests/gitlabApiRequest.test.js
@@ -52,11 +52,27 @@ test('builds URL correctly when server lacks trailing slash', async () => {
 });
 
 test('getMergeRequestDiscussion builds correct endpoint', async () => {
-	const ctx = mockContext({ projectId: 1 });
-	const result = await getMergeRequestDiscussion.call(ctx, 1234, '123abc');
-	assert.strictEqual(
-		ctx.calls.options.uri,
-		'https://gitlab.example.com/api/v4/projects/1/merge_requests/1234/discussions/123abc',
-	);
-	assert.deepStrictEqual(result, { ok: true });
+        const ctx = mockContext({ projectId: 1 });
+        const result = await getMergeRequestDiscussion.call(ctx, 1234, '123abc');
+        assert.strictEqual(
+                ctx.calls.options.uri,
+                'https://gitlab.example.com/api/v4/projects/1/merge_requests/1234/discussions/123abc',
+        );
+        assert.deepStrictEqual(result, { ok: true });
+});
+
+test('gitlabApiRequest supports DELETE method', async () => {
+        const ctx = mockContext();
+        await gitlabApiRequest.call(
+                ctx,
+                'DELETE',
+                '/projects/1/repository/branches/foo',
+                {},
+                undefined,
+        );
+        assert.strictEqual(ctx.calls.options.method, 'DELETE');
+        assert.strictEqual(
+                ctx.calls.options.uri,
+                'https://gitlab.example.com/api/v4/projects/1/repository/branches/foo',
+        );
 });


### PR DESCRIPTION
## Summary
- allow deleting branches via new `delete` operation
- implement DELETE logic in execution
- document new option in README
- cover DELETE method in api request tests

## Testing
- `npm test`