### PR TITLE
Add pipeline job listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ one of its operations.
 * `cancel` – Cancel a pipeline
 * `get` – Get a pipeline by ID
 * `getAll` – List pipelines
+* `getJobs` – List jobs for a pipeline
 
 ### File
 * `get` – Retrieve a file

--- a/nodes/GitlabExtended/GitlabExtended.node.ts
+++ b/nodes/GitlabExtended/GitlabExtended.node.ts
@@ -77,6 +77,7 @@ export class GitlabExtended implements INodeType {
                                        { name: 'Cancel', value: 'cancel', action: 'Cancel a pipeline' },
                                        { name: 'Create', value: 'create', action: 'Create a pipeline' },
                                        { name: 'Get', value: 'get', action: 'Get a pipeline' },
+                                       { name: 'Get Jobs', value: 'getJobs', action: 'List pipeline jobs' },
                                        { name: 'Get Many', value: 'getAll', action: 'List pipelines' },
                                        { name: 'Retry', value: 'retry', action: 'Retry a pipeline' },
                                ],
@@ -172,15 +173,15 @@ export class GitlabExtended implements INodeType {
                                 default: 'main',
                         },
 			{
-				displayName: 'Pipeline ID',
-				name: 'pipelineId',
-                                type: 'number',
-                                required: true,
-                                typeOptions: { minValue: 1 },
+                               displayName: 'Pipeline ID',
+                               name: 'pipelineId',
+                               type: 'number',
+                               required: true,
+                               typeOptions: { minValue: 1 },
                                displayOptions: {
                                        show: {
                                                resource: ['pipeline'],
-                                               operation: ['get', 'cancel', 'retry'],
+                                               operation: ['get', 'cancel', 'retry', 'getJobs'],
                                        },
                                },
                                 description: 'Numeric ID of the pipeline (must be positive)',
@@ -192,10 +193,10 @@ export class GitlabExtended implements INodeType {
 				type: 'boolean',
 				displayOptions: {
 					show: {
-						resource: ['branch', 'pipeline', 'file', 'mergeRequest'],
-                                                operation: ['getAll', 'list', 'getDiscussions'],
-					},
-				},
+                                               resource: ['branch', 'pipeline', 'file', 'mergeRequest'],
+                                               operation: ['getAll', 'list', 'getDiscussions', 'getJobs'],
+                                       },
+                               },
 				default: false,
 				description: 'Whether to return all results or only up to a given limit',
 			},
@@ -205,11 +206,11 @@ export class GitlabExtended implements INodeType {
 				type: 'number',
 				displayOptions: {
 					show: {
-						resource: ['branch', 'pipeline', 'file', 'mergeRequest'],
-                                                operation: ['getAll', 'list', 'getDiscussions'],
-						returnAll: [false],
-					},
-				},
+                                               resource: ['branch', 'pipeline', 'file', 'mergeRequest'],
+                                               operation: ['getAll', 'list', 'getDiscussions', 'getJobs'],
+                                               returnAll: [false],
+                                       },
+                               },
 				typeOptions: {
 					minValue: 1,
 				},
@@ -661,6 +662,19 @@ export class GitlabExtended implements INodeType {
                                        returnAll = this.getNodeParameter('returnAll', i);
                                        if (!returnAll) qs.per_page = this.getNodeParameter('limit', i);
                                        endpoint = `${base}/pipelines`;
+                               } else if (operation === 'getJobs') {
+                                       requestMethod = 'GET';
+                                       const id = this.getNodeParameter('pipelineId', i) as number;
+                                       if (id <= 0) {
+                                               throw new NodeOperationError(
+                                                       this.getNode(),
+                                                       'pipelineId must be a positive number',
+                                                       { itemIndex: i },
+                                               );
+                                       }
+                                       returnAll = this.getNodeParameter('returnAll', i);
+                                       if (!returnAll) qs.per_page = this.getNodeParameter('limit', i);
+                                       endpoint = `${base}/pipelines/${id}/jobs`;
                                } else if (operation === 'cancel' || operation === 'retry') {
                                        requestMethod = 'POST';
                                        const id = this.getNodeParameter('pipelineId', i) as number;

--- a/tests/pipelineGetJobs.test.js
+++ b/tests/pipelineGetJobs.test.js
@@ -1,0 +1,45 @@
+import assert from 'node:assert';
+import test from 'node:test';
+import { GitlabExtended } from '../dist/nodes/GitlabExtended/GitlabExtended.node.js';
+
+function createContext(params) {
+  const calls = {};
+  return {
+    calls,
+    getInputData() {
+      return [{ json: {} }];
+    },
+    getNodeParameter(name) {
+      return params[name];
+    },
+    async getCredentials() {
+      return { server: 'https://gitlab.example.com', accessToken: 't', projectId: 1 };
+    },
+    helpers: {
+      async requestWithAuthentication(name, options) {
+        calls.options = options;
+        return {};
+      },
+      constructExecutionMetaData(data) { return data; },
+      returnJsonArray(data) {
+        return [{ json: data }];
+      },
+    },
+    getNode() { return {}; },
+  };
+}
+
+test('getJobs builds correct endpoint and respects limit', async () => {
+  const node = new GitlabExtended();
+  const ctx = createContext({
+    resource: 'pipeline',
+    operation: 'getJobs',
+    pipelineId: 5,
+    returnAll: false,
+    limit: 3,
+  });
+  await node.execute.call(ctx);
+  assert.strictEqual(ctx.calls.options.uri,
+    'https://gitlab.example.com/api/v4/projects/1/pipelines/5/jobs');
+  assert.strictEqual(ctx.calls.options.qs.per_page, 3);
+});


### PR DESCRIPTION
## Summary
- add `getJobs` option under the pipeline operations
- allow using `getJobs` in the node parameters
- support job listing in execute logic
- document the new operation
- test the `getJobs` endpoint

## Testing
- `npm test`