### PR TITLE
Add pipeline delete and artifact download

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ one of its operations.
 * `get` – Get a pipeline by ID
 * `getAll` – List pipelines
 * `getJobs` – List jobs for a pipeline
+* `delete` – Delete a pipeline
+* `downloadArtifacts` – Download artifacts from a pipeline
 
 ### File
 * `create` – Create a file
@@ -97,7 +99,7 @@ required for your chosen operation.
 | `developersCanPush` | Allow developers to push |
 | `developersCanMerge` | Allow developers to merge |
 | `pipelineId` | Numeric pipeline ID (positive) |
-| `pipelineRef` | Branch or tag for pipelines |
+| `pipelineRef` | Branch or tag for pipelines and artifact downloads |
 | `path` | File or directory path |
 | `fileRef` | Branch, tag or commit for file operations |
 | `title` | Title for issues and merge requests |

--- a/nodes/GitlabExtended/GitlabExtended.node.ts
+++ b/nodes/GitlabExtended/GitlabExtended.node.ts
@@ -80,6 +80,8 @@ export class GitlabExtended implements INodeType {
                                options: [
                                        { name: 'Cancel', value: 'cancel', action: 'Cancel a pipeline' },
                                        { name: 'Create', value: 'create', action: 'Create a pipeline' },
+                                       { name: 'Delete', value: 'delete', action: 'Delete a pipeline' },
+                                       { name: 'Download Artifacts', value: 'downloadArtifacts', action: 'Download artifacts' },
                                        { name: 'Get', value: 'get', action: 'Get a pipeline' },
                                        { name: 'Get Jobs', value: 'getJobs', action: 'List pipeline jobs' },
                                        { name: 'Get Many', value: 'getAll', action: 'List pipelines' },
@@ -235,7 +237,7 @@ export class GitlabExtended implements INodeType {
                                displayOptions: {
                                        show: {
                                                resource: ['pipeline'],
-                                               operation: ['get', 'cancel', 'retry', 'getJobs'],
+                                               operation: ['get', 'cancel', 'retry', 'getJobs', 'delete', 'downloadArtifacts'],
                                        },
                                },
                                 description: 'Numeric ID of the pipeline (must be positive)',
@@ -275,7 +277,7 @@ export class GitlabExtended implements INodeType {
                                 displayName: 'Ref',
                                 name: 'pipelineRef',
                                 type: 'string',
-                                displayOptions: { show: { resource: ['pipeline'], operation: ['create'] } },
+                               displayOptions: { show: { resource: ['pipeline'], operation: ['create', 'downloadArtifacts'] } },
                                 description: "Branch or tag that triggers the pipeline, such as 'main'",
                                 default: 'main',
                         },
@@ -809,6 +811,29 @@ export class GitlabExtended implements INodeType {
                                                );
                                        }
                                        endpoint = `${base}/pipelines/${id}/${operation}`;
+                               } else if (operation === 'delete') {
+                                       requestMethod = 'DELETE';
+                                       const id = this.getNodeParameter('pipelineId', i) as number;
+                                       if (id <= 0) {
+                                               throw new NodeOperationError(
+                                                       this.getNode(),
+                                                       'pipelineId must be a positive number',
+                                                       { itemIndex: i },
+                                               );
+                                       }
+                                       endpoint = `${base}/pipelines/${id}`;
+                               } else if (operation === 'downloadArtifacts') {
+                                       requestMethod = 'GET';
+                                       const id = this.getNodeParameter('pipelineId', i) as number;
+                                       if (id <= 0) {
+                                               throw new NodeOperationError(
+                                                       this.getNode(),
+                                                       'pipelineId must be a positive number',
+                                                       { itemIndex: i },
+                                               );
+                                       }
+                                       const ref = this.getNodeParameter('pipelineRef', i) as string;
+                                       endpoint = `${base}/pipelines/${id}/jobs/artifacts/${ref}/download`;
                                }
 			} else if (resource === 'file') {
                                 if (operation === 'get') {


### PR DESCRIPTION
## Summary
- extend pipeline operations
- allow deleting pipelines and downloading artifacts
- document options in README
- test endpoint generation for new operations

## Testing
- `npm test`