### PR TITLE
Add GitLab group operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ one of its operations.
 * `delete` – Delete a pipeline
 * `downloadArtifacts` – Download artifacts from a pipeline
 
+### Group
+* `create` – Create a group
+* `get` – Get a group
+* `delete` – Delete a group
+* `getMembers` – List group members
+
 ### File
 * `create` – Create a file
 * `update` – Update a file
@@ -139,6 +145,9 @@ required for your chosen operation.
 | `queryParameters` | JSON query parameters |
 | `returnAll` | Return every result when listing |
 | `limit` | Maximum number of results |
+| `groupId` | Numeric group ID |
+| `groupName` | Name when creating a group |
+| `groupPath` | Path when creating a group |
 
 ## Credentials
 

--- a/tests/groupOperations.test.js
+++ b/tests/groupOperations.test.js
@@ -1,0 +1,56 @@
+import assert from 'node:assert';
+import test from 'node:test';
+import { GitlabExtended } from '../dist/nodes/GitlabExtended/GitlabExtended.node.js';
+
+function createContext(params) {
+  const calls = {};
+  return {
+    calls,
+    getInputData() { return [{ json: {} }]; },
+    getNodeParameter(name) { return params[name]; },
+    async getCredentials() {
+      return { server: 'https://gitlab.example.com', accessToken: 't' };
+    },
+    helpers: {
+      async requestWithAuthentication(name, options) { calls.name = name; calls.options = options; return {}; },
+      constructExecutionMetaData(data) { return data; },
+      returnJsonArray(data) { return [{ json: data }]; },
+    },
+    getNode() { return {}; },
+  };
+}
+
+test('create builds correct endpoint and body', async () => {
+  const node = new GitlabExtended();
+  const ctx = createContext({ resource: 'group', operation: 'create', groupName: 'Dev', groupPath: 'dev' });
+  await node.execute.call(ctx);
+  assert.strictEqual(ctx.calls.name, 'gitlabExtendedApi');
+  assert.strictEqual(ctx.calls.options.method, 'POST');
+  assert.strictEqual(ctx.calls.options.uri, 'https://gitlab.example.com/api/v4/groups');
+  assert.deepStrictEqual(ctx.calls.options.body, { name: 'Dev', path: 'dev' });
+});
+
+test('get builds correct endpoint', async () => {
+  const node = new GitlabExtended();
+  const ctx = createContext({ resource: 'group', operation: 'get', groupId: 5 });
+  await node.execute.call(ctx);
+  assert.strictEqual(ctx.calls.options.method, 'GET');
+  assert.strictEqual(ctx.calls.options.uri, 'https://gitlab.example.com/api/v4/groups/5');
+});
+
+test('delete builds correct endpoint', async () => {
+  const node = new GitlabExtended();
+  const ctx = createContext({ resource: 'group', operation: 'delete', groupId: 7 });
+  await node.execute.call(ctx);
+  assert.strictEqual(ctx.calls.options.method, 'DELETE');
+  assert.strictEqual(ctx.calls.options.uri, 'https://gitlab.example.com/api/v4/groups/7');
+});
+
+test('getMembers builds correct endpoint and respects limit', async () => {
+  const node = new GitlabExtended();
+  const ctx = createContext({ resource: 'group', operation: 'getMembers', groupId: 9, returnAll: false, limit: 2 });
+  await node.execute.call(ctx);
+  assert.strictEqual(ctx.calls.options.method, 'GET');
+  assert.strictEqual(ctx.calls.options.uri, 'https://gitlab.example.com/api/v4/groups/9/members');
+  assert.strictEqual(ctx.calls.options.qs.per_page, 2);
+});


### PR DESCRIPTION
## Summary
- add `group` resource and operations
- document group usage in README
- test group operations

## Testing
- `npm test`