### PR TITLE
Add GitLab release support

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,13 @@ one of its operations.
 * `getAll` – List tags
 * `delete` – Delete a tag
 
+### Release
+* `create` – Create a release
+* `update` – Update a release
+* `get` – Get a release
+* `getAll` – List releases
+* `delete` – Delete a release
+
 ### Group
 * `create` – Create a group
 * `get` – Get a group

--- a/nodes/GitlabExtended/GitlabExtended.node.ts
+++ b/nodes/GitlabExtended/GitlabExtended.node.ts
@@ -1060,7 +1060,17 @@ export class GitlabExtended implements INodeType {
                                        body.name = this.getNodeParameter('name', i);
                                        body.description = this.getNodeParameter('releaseDescription', i, '');
                                        const assets = this.getNodeParameter('assets', i, '');
-                                       if (assets) body.assets = JSON.parse(assets as string);
+                                       if (assets) {
+                                           try {
+                                               body.assets = JSON.parse(assets as string);
+                                           } catch (error) {
+                                               throw new NodeOperationError(
+                                                   this.getNode(),
+                                                   'Invalid JSON in "assets" parameter',
+                                                   { itemIndex: i },
+                                               );
+                                           }
+                                       }
                                        endpoint = `${base}/releases`;
                                } else if (operation === 'update') {
                                        requestMethod = 'PUT';

--- a/tests/releaseOperations.test.js
+++ b/tests/releaseOperations.test.js
@@ -1,0 +1,64 @@
+import assert from 'node:assert';
+import test from 'node:test';
+import { GitlabExtended } from '../dist/nodes/GitlabExtended/GitlabExtended.node.js';
+
+function createContext(params) {
+  const calls = {};
+  return {
+    calls,
+    getInputData() { return [{ json: {} }]; },
+    getNodeParameter(name) { return params[name]; },
+    async getCredentials() {
+      return { server: 'https://gitlab.example.com', accessToken: 't', projectId: 1 };
+    },
+    helpers: {
+      async requestWithAuthentication(name, options) { calls.options = options; return {}; },
+      constructExecutionMetaData(data) { return data; },
+      returnJsonArray(data) { return [{ json: data }]; },
+    },
+    getNode() { return {}; },
+  };
+}
+
+test('create builds correct endpoint and body', async () => {
+  const node = new GitlabExtended();
+  const ctx = createContext({ resource: 'release', operation: 'create', tagName: 'v1.0', name: '1.0', releaseDescription: 'desc', assets: '{"links":[]}' });
+  await node.execute.call(ctx);
+  assert.strictEqual(ctx.calls.options.method, 'POST');
+  assert.strictEqual(ctx.calls.options.uri, 'https://gitlab.example.com/api/v4/projects/1/releases');
+  assert.deepStrictEqual(ctx.calls.options.body, { tag_name: 'v1.0', name: '1.0', description: 'desc', assets: { links: [] } });
+});
+
+test('update builds correct endpoint and body', async () => {
+  const node = new GitlabExtended();
+  const ctx = createContext({ resource: 'release', operation: 'update', tagName: 'v1.0', name: '1.1', releaseDescription: 'new', assets: '' });
+  await node.execute.call(ctx);
+  assert.strictEqual(ctx.calls.options.method, 'PUT');
+  assert.strictEqual(ctx.calls.options.uri, 'https://gitlab.example.com/api/v4/projects/1/releases/v1.0');
+  assert.deepStrictEqual(ctx.calls.options.body, { name: '1.1', description: 'new' });
+});
+
+test('get builds correct endpoint', async () => {
+  const node = new GitlabExtended();
+  const ctx = createContext({ resource: 'release', operation: 'get', tagName: 'v1.0' });
+  await node.execute.call(ctx);
+  assert.strictEqual(ctx.calls.options.method, 'GET');
+  assert.strictEqual(ctx.calls.options.uri, 'https://gitlab.example.com/api/v4/projects/1/releases/v1.0');
+});
+
+test('getAll builds correct endpoint with limit', async () => {
+  const node = new GitlabExtended();
+  const ctx = createContext({ resource: 'release', operation: 'getAll', returnAll: false, limit: 2 });
+  await node.execute.call(ctx);
+  assert.strictEqual(ctx.calls.options.method, 'GET');
+  assert.strictEqual(ctx.calls.options.uri, 'https://gitlab.example.com/api/v4/projects/1/releases');
+  assert.strictEqual(ctx.calls.options.qs.per_page, 2);
+});
+
+test('delete builds correct endpoint', async () => {
+  const node = new GitlabExtended();
+  const ctx = createContext({ resource: 'release', operation: 'delete', tagName: 'v1.0' });
+  await node.execute.call(ctx);
+  assert.strictEqual(ctx.calls.options.method, 'DELETE');
+  assert.strictEqual(ctx.calls.options.uri, 'https://gitlab.example.com/api/v4/projects/1/releases/v1.0');
+});


### PR DESCRIPTION
## Summary
- support release operations in GitLab Extended node
- document release operations
- test release endpoints

## Testing
- `npm run lint`
- `npm test`
