### PR TITLE
Fix pagination using x-next-page header

### DIFF
--- a/nodes/GitlabExtended/GenericFunctions.ts
+++ b/nodes/GitlabExtended/GenericFunctions.ts
@@ -74,7 +74,7 @@ export async function gitlabApiRequestAllItems(
 		});
 		query.page++;
 		returnData.push.apply(returnData, responseData.body as IDataObject[]);
-	} while (responseData.headers.link?.includes('next'));
+        } while (responseData.headers['x-next-page']);
 	return returnData;
 }
 


### PR DESCRIPTION
## Summary
- use the `x-next-page` header to paginate in `gitlabApiRequestAllItems`
- test looping when multiple pages are present

## Testing
- `npm test`