### PR TITLE
Add project base utility tests

### DIFF
--- a/tests/gitlabEncoding.test.js
+++ b/tests/gitlabEncoding.test.js
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
 import test from 'node:test';
-import { buildProjectBase } from '../dist/nodes/GitlabExtended/GenericFunctions.js';
+import { buildProjectBase } from '../src/nodes/GitlabExtended/GenericFunctions.js';
 
 test('encodes spaces in owner and repo', () => {
   const base = buildProjectBase({ projectOwner: 'my group', projectName: 'my repo' });

--- a/tests/gitlabEncoding.test.js
+++ b/tests/gitlabEncoding.test.js
@@ -1,40 +1,33 @@
 import assert from 'node:assert';
 import test from 'node:test';
-function computeBase(ownerValue, repoValue, projectId) {
-  if (projectId) {
-    return `/projects/${projectId}`;
-  }
-  const owner = encodeURIComponent(ownerValue);
-  const repo = encodeURIComponent(repoValue);
-  return `/projects/${owner}%2F${repo}`;
-}
+import { buildProjectBase } from '../dist/nodes/GitlabExtended/GenericFunctions.js';
 
 test('encodes spaces in owner and repo', () => {
-  const base = computeBase('my group', 'my repo');
+  const base = buildProjectBase({ projectOwner: 'my group', projectName: 'my repo' });
   assert.strictEqual(base, '/projects/my%20group%2Fmy%20repo');
 });
 
 test('encodes slashes in owner', () => {
-  const base = computeBase('group/sub', 'my repo');
+  const base = buildProjectBase({ projectOwner: 'group/sub', projectName: 'my repo' });
   assert.strictEqual(base, '/projects/group%2Fsub%2Fmy%20repo');
 });
 
 test('encodes special characters', () => {
-  const base = computeBase('A&B', 'C # repo');
+  const base = buildProjectBase({ projectOwner: 'A&B', projectName: 'C # repo' });
   assert.strictEqual(base, '/projects/A%26B%2FC%20%23%20repo');
 });
 
 test('encodes slashes in repository', () => {
-  const base = computeBase('mygroup', 'sub/repo');
+  const base = buildProjectBase({ projectOwner: 'mygroup', projectName: 'sub/repo' });
   assert.strictEqual(base, '/projects/mygroup%2Fsub%2Frepo');
 });
 
 test('encodes slashes and spaces in both parts', () => {
-  const base = computeBase('group/sub name', 'repo/with space');
+  const base = buildProjectBase({ projectOwner: 'group/sub name', projectName: 'repo/with space' });
   assert.strictEqual(base, '/projects/group%2Fsub%20name%2Frepo%2Fwith%20space');
 });
 
 test('uses project ID when provided', () => {
-  const base = computeBase('ignored', 'ignored', 123);
+  const base = buildProjectBase({ projectOwner: 'ignored', projectName: 'ignored', projectId: 123 });
   assert.strictEqual(base, '/projects/123');
 });

--- a/tests/gitlabEncoding.test.js
+++ b/tests/gitlabEncoding.test.js
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
 import test from 'node:test';
-import { buildProjectBase } from '../src/nodes/GitlabExtended/GenericFunctions.js';
+import { buildProjectBase } from '../dist/nodes/GitlabExtended/GenericFunctions.js';
 
 test('encodes spaces in owner and repo', () => {
   const base = buildProjectBase({ projectOwner: 'my group', projectName: 'my repo' });


### PR DESCRIPTION
## Summary
- ensure the project base encoding helper is imported in the encoding tests

## Testing
- `npm test`
