### PR TITLE
Add validators and use in branch handler

### DIFF
--- a/nodes/GitlabExtended/resources/branch.ts
+++ b/nodes/GitlabExtended/resources/branch.ts
@@ -6,6 +6,7 @@ import type {
 } from 'n8n-workflow';
 import { NodeOperationError } from 'n8n-workflow';
 import { gitlabApiRequest, gitlabApiRequestAllItems, buildProjectBase } from '../GenericFunctions';
+import { requireString } from '../validators';
 
 /**
  * Handles branch-related operations in a GitLab project, such as creating, retrieving, 
@@ -60,47 +61,35 @@ export async function handleBranch(
 		const branch = this.getNodeParameter('branch', itemIndex) as string;
 		endpoint = `${base}/repository/branches/${encodeURIComponent(branch)}`;
 	} else if (operation === 'rename') {
-		requestMethod = 'PUT';
-		const branch = this.getNodeParameter('branch', itemIndex) as string;
-		const newBranch = this.getNodeParameter('newBranch', itemIndex) as string;
-		if (!branch) {
-			throw new NodeOperationError(this.getNode(), 'branch must not be empty', { itemIndex });
-		}
-		if (!newBranch) {
-			throw new NodeOperationError(this.getNode(), 'newBranch must not be empty', { itemIndex });
-		}
-		body.new_branch = newBranch;
-		endpoint = `${base}/repository/branches/${encodeURIComponent(branch)}`;
-	} else if (operation === 'protect') {
-		requestMethod = 'POST';
-		const branch = this.getNodeParameter('branch', itemIndex) as string;
-		if (!branch) {
-			throw new NodeOperationError(this.getNode(), 'branch must not be empty', { itemIndex });
-		}
-		body.name = branch;
-		body.developers_can_push = this.getNodeParameter('developersCanPush', itemIndex, false);
-		body.developers_can_merge = this.getNodeParameter('developersCanMerge', itemIndex, false);
-		endpoint = `${base}/protected_branches`;
-	} else if (operation === 'unprotect') {
-		requestMethod = 'DELETE';
-		const branch = this.getNodeParameter('branch', itemIndex) as string;
-		if (!branch) {
-			throw new NodeOperationError(this.getNode(), 'branch must not be empty', { itemIndex });
-		}
-		endpoint = `${base}/protected_branches/${encodeURIComponent(branch)}`;
-	} else if (operation === 'merge') {
-		requestMethod = 'POST';
-		const branch = this.getNodeParameter('branch', itemIndex) as string;
-		const target = this.getNodeParameter('targetBranch', itemIndex) as string;
-		if (!branch) {
-			throw new NodeOperationError(this.getNode(), 'branch must not be empty', { itemIndex });
-		}
-		if (!target) {
-			throw new NodeOperationError(this.getNode(), 'targetBranch must not be empty', { itemIndex });
-		}
-		body.source_branch = branch;
-		body.target_branch = target;
-		endpoint = `${base}/repository/merges`;
+               requestMethod = 'PUT';
+               const branch = this.getNodeParameter('branch', itemIndex) as string;
+               const newBranch = this.getNodeParameter('newBranch', itemIndex) as string;
+               requireString.call(this, branch, 'branch', itemIndex);
+               requireString.call(this, newBranch, 'newBranch', itemIndex);
+               body.new_branch = newBranch;
+               endpoint = `${base}/repository/branches/${encodeURIComponent(branch)}`;
+       } else if (operation === 'protect') {
+               requestMethod = 'POST';
+               const branch = this.getNodeParameter('branch', itemIndex) as string;
+               requireString.call(this, branch, 'branch', itemIndex);
+               body.name = branch;
+               body.developers_can_push = this.getNodeParameter('developersCanPush', itemIndex, false);
+               body.developers_can_merge = this.getNodeParameter('developersCanMerge', itemIndex, false);
+               endpoint = `${base}/protected_branches`;
+       } else if (operation === 'unprotect') {
+               requestMethod = 'DELETE';
+               const branch = this.getNodeParameter('branch', itemIndex) as string;
+               requireString.call(this, branch, 'branch', itemIndex);
+               endpoint = `${base}/protected_branches/${encodeURIComponent(branch)}`;
+       } else if (operation === 'merge') {
+               requestMethod = 'POST';
+               const branch = this.getNodeParameter('branch', itemIndex) as string;
+               const target = this.getNodeParameter('targetBranch', itemIndex) as string;
+               requireString.call(this, branch, 'branch', itemIndex);
+               requireString.call(this, target, 'targetBranch', itemIndex);
+               body.source_branch = branch;
+               body.target_branch = target;
+               endpoint = `${base}/repository/merges`;
 	} else {
 		throw new NodeOperationError(this.getNode(), `The operation "${operation}" is not supported.`, { itemIndex });
 	}

--- a/nodes/GitlabExtended/validators.ts
+++ b/nodes/GitlabExtended/validators.ts
@@ -1,0 +1,30 @@
+import type { IExecuteFunctions } from 'n8n-workflow';
+import { NodeOperationError } from 'n8n-workflow';
+
+/**
+ * Ensure the given string value is not empty.
+ */
+export function requireString(
+	this: IExecuteFunctions,
+	value: string,
+	field: string,
+	itemIndex: number,
+): void {
+	if (!value) {
+		throw new NodeOperationError(this.getNode(), `${field} must not be empty`, { itemIndex });
+	}
+}
+
+/**
+ * Ensure the given numeric value is positive.
+ */
+export function requirePositive(
+	this: IExecuteFunctions,
+	value: number,
+	field: string,
+	itemIndex: number,
+): void {
+	if (value <= 0) {
+		throw new NodeOperationError(this.getNode(), `${field} must be a positive number`, { itemIndex });
+	}
+}


### PR DESCRIPTION
## Summary
- add reusable validators for string and positive number checks
- use `requireString` in `handleBranch`

## Testing
- `npm test`