### PR TITLE
Add createContext helper for branch tests

### DIFF
--- a/tests/branchOperations.test.js
+++ b/tests/branchOperations.test.js
@@ -1,31 +1,7 @@
 import assert from 'node:assert';
 import test from 'node:test';
 import { GitlabExtended } from '../dist/nodes/GitlabExtended/GitlabExtended.node.js';
-
-function createContext(params) {
-  const calls = {};
-  return {
-    calls,
-    getInputData() {
-      return [{ json: {} }];
-    },
-    getNodeParameter(name) {
-      return params[name];
-    },
-    async getCredentials() {
-      return { server: 'https://gitlab.example.com', accessToken: 't', projectId: 1 };
-    },
-    helpers: {
-      async requestWithAuthentication(name, options) {
-        calls.options = options;
-        return {};
-      },
-      constructExecutionMetaData(data) { return data; },
-      returnJsonArray(data) { return [{ json: data }]; },
-    },
-    getNode() { return {}; },
-  };
-}
+import createContext from './helpers/createContext.js';
 
 test('rename builds correct endpoint and body', async () => {
   const node = new GitlabExtended();

--- a/tests/helpers/createContext.js
+++ b/tests/helpers/createContext.js
@@ -1,0 +1,30 @@
+export default function createContext(params) {
+  const calls = {};
+  return {
+    calls,
+    getInputData() {
+      return [{ json: {} }];
+    },
+    getNodeParameter(name) {
+      return params[name];
+    },
+    async getCredentials() {
+      return { server: 'https://gitlab.example.com', accessToken: 't', projectId: 1 };
+    },
+    helpers: {
+      async requestWithAuthentication(name, options) {
+        calls.options = options;
+        return {};
+      },
+      constructExecutionMetaData(data) {
+        return data;
+      },
+      returnJsonArray(data) {
+        return [{ json: data }];
+      },
+    },
+    getNode() {
+      return {};
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- add a helper to create the execution context for tests
- refactor branchOperations.test.js to use the helper

## Testing
- `npm test`
