### PR TITLE
Add merge request operation tests

### DIFF
--- a/tests/mergeRequestOperations.test.js
+++ b/tests/mergeRequestOperations.test.js
@@ -148,3 +148,227 @@ test('postDiscussionNote builds suggestion with position', async () => {
   });
   assert.ok(ctx.calls.params.includes('positionType'));
 });
+
+test('get builds correct endpoint', async () => {
+  const node = new GitlabExtended();
+  const ctx = createContext({ resource: 'mergeRequest', operation: 'get', mergeRequestIid: 1 });
+  await node.execute.call(ctx);
+  assert.strictEqual(ctx.calls.options.method, 'GET');
+  assert.strictEqual(
+    ctx.calls.options.uri,
+    'https://gitlab.example.com/api/v4/projects/1/merge_requests/1'
+  );
+});
+
+test('getAll builds correct endpoint with limit', async () => {
+  const node = new GitlabExtended();
+  const ctx = createContext({ resource: 'mergeRequest', operation: 'getAll', returnAll: false, limit: 3 });
+  await node.execute.call(ctx);
+  assert.strictEqual(ctx.calls.options.method, 'GET');
+  assert.strictEqual(
+    ctx.calls.options.uri,
+    'https://gitlab.example.com/api/v4/projects/1/merge_requests'
+  );
+  assert.strictEqual(ctx.calls.options.qs.per_page, 3);
+});
+
+test('getAll builds correct endpoint when returnAll true', async () => {
+  const node = new GitlabExtended();
+  const ctx = createContext({ resource: 'mergeRequest', operation: 'getAll', returnAll: true });
+  ctx.helpers.requestWithAuthentication = async (name, options) => {
+    ctx.calls.options = JSON.parse(JSON.stringify(options));
+    return { body: [], headers: { 'x-next-page': '' } };
+  };
+  await node.execute.call(ctx);
+  assert.strictEqual(ctx.calls.options.method, 'GET');
+  assert.strictEqual(
+    ctx.calls.options.uri,
+    'https://gitlab.example.com/api/v4/projects/1/merge_requests'
+  );
+  assert.strictEqual(ctx.calls.options.qs.per_page, 100);
+  assert.strictEqual(ctx.calls.options.qs.page, 1);
+});
+
+test('getChanges builds correct endpoint', async () => {
+  const node = new GitlabExtended();
+  const ctx = createContext({ resource: 'mergeRequest', operation: 'getChanges', mergeRequestIid: 11 });
+  await node.execute.call(ctx);
+  assert.strictEqual(ctx.calls.options.method, 'GET');
+  assert.strictEqual(
+    ctx.calls.options.uri,
+    'https://gitlab.example.com/api/v4/projects/1/merge_requests/11/changes'
+  );
+});
+
+test('getDiscussions builds correct endpoint with limit', async () => {
+  const node = new GitlabExtended();
+  const ctx = createContext({ resource: 'mergeRequest', operation: 'getDiscussions', mergeRequestIid: 12, returnAll: false, limit: 2 });
+  await node.execute.call(ctx);
+  assert.strictEqual(ctx.calls.options.method, 'GET');
+  assert.strictEqual(
+    ctx.calls.options.uri,
+    'https://gitlab.example.com/api/v4/projects/1/merge_requests/12/discussions'
+  );
+  assert.strictEqual(ctx.calls.options.qs.per_page, 2);
+});
+
+test('getDiscussions builds correct endpoint when returnAll true', async () => {
+  const node = new GitlabExtended();
+  const ctx = createContext({ resource: 'mergeRequest', operation: 'getDiscussions', mergeRequestIid: 13, returnAll: true });
+  ctx.helpers.requestWithAuthentication = async (name, options) => {
+    ctx.calls.options = JSON.parse(JSON.stringify(options));
+    return { body: [], headers: { 'x-next-page': '' } };
+  };
+  await node.execute.call(ctx);
+  assert.strictEqual(ctx.calls.options.method, 'GET');
+  assert.strictEqual(
+    ctx.calls.options.uri,
+    'https://gitlab.example.com/api/v4/projects/1/merge_requests/13/discussions'
+  );
+  assert.strictEqual(ctx.calls.options.qs.per_page, 100);
+  assert.strictEqual(ctx.calls.options.qs.page, 1);
+});
+
+test('getDiscussion builds correct endpoint', async () => {
+  const node = new GitlabExtended();
+  const ctx = createContext({ resource: 'mergeRequest', operation: 'getDiscussion', mergeRequestIid: 14, discussionId: 'd1' });
+  await node.execute.call(ctx);
+  assert.strictEqual(ctx.calls.options.method, 'GET');
+  assert.strictEqual(
+    ctx.calls.options.uri,
+    'https://gitlab.example.com/api/v4/projects/1/merge_requests/14/discussions/d1'
+  );
+});
+
+test('updateDiscussion builds correct endpoint and body', async () => {
+  const node = new GitlabExtended();
+  const ctx = createContext({ resource: 'mergeRequest', operation: 'updateDiscussion', mergeRequestIid: 15, discussionId: 'd2', resolved: true });
+  await node.execute.call(ctx);
+  assert.strictEqual(ctx.calls.options.method, 'PUT');
+  assert.strictEqual(
+    ctx.calls.options.uri,
+    'https://gitlab.example.com/api/v4/projects/1/merge_requests/15/discussions/d2'
+  );
+  assert.deepStrictEqual(ctx.calls.options.body, { resolved: true });
+});
+
+test('resolveDiscussion builds correct endpoint and body', async () => {
+  const node = new GitlabExtended();
+  const ctx = createContext({ resource: 'mergeRequest', operation: 'resolveDiscussion', mergeRequestIid: 16, discussionId: 'd3', resolved: false });
+  await node.execute.call(ctx);
+  assert.strictEqual(ctx.calls.options.method, 'PUT');
+  assert.strictEqual(
+    ctx.calls.options.uri,
+    'https://gitlab.example.com/api/v4/projects/1/merge_requests/16/discussions/d3'
+  );
+  assert.deepStrictEqual(ctx.calls.options.body, { resolved: false });
+});
+
+test('deleteDiscussion builds correct endpoint', async () => {
+  const node = new GitlabExtended();
+  const ctx = createContext({ resource: 'mergeRequest', operation: 'deleteDiscussion', mergeRequestIid: 17, discussionId: 'd4' });
+  await node.execute.call(ctx);
+  assert.strictEqual(ctx.calls.options.method, 'DELETE');
+  assert.strictEqual(
+    ctx.calls.options.uri,
+    'https://gitlab.example.com/api/v4/projects/1/merge_requests/17/discussions/d4'
+  );
+});
+
+test('getNote builds correct endpoint', async () => {
+  const node = new GitlabExtended();
+  const ctx = createContext({ resource: 'mergeRequest', operation: 'getNote', mergeRequestIid: 18, noteId: 5 });
+  await node.execute.call(ctx);
+  assert.strictEqual(ctx.calls.options.method, 'GET');
+  assert.strictEqual(
+    ctx.calls.options.uri,
+    'https://gitlab.example.com/api/v4/projects/1/merge_requests/18/notes/5'
+  );
+});
+
+test('updateNote builds correct endpoint and body', async () => {
+  const node = new GitlabExtended();
+  const ctx = createContext({ resource: 'mergeRequest', operation: 'updateNote', mergeRequestIid: 19, discussionId: 'd5', noteId: 6, body: 'edit' });
+  await node.execute.call(ctx);
+  assert.strictEqual(ctx.calls.options.method, 'PUT');
+  assert.strictEqual(
+    ctx.calls.options.uri,
+    'https://gitlab.example.com/api/v4/projects/1/merge_requests/19/discussions/d5/notes/6'
+  );
+  assert.deepStrictEqual(ctx.calls.options.body, { body: 'edit' });
+});
+
+test('deleteNote builds correct endpoint', async () => {
+  const node = new GitlabExtended();
+  const ctx = createContext({ resource: 'mergeRequest', operation: 'deleteNote', mergeRequestIid: 20, noteId: 7 });
+  await node.execute.call(ctx);
+  assert.strictEqual(ctx.calls.options.method, 'DELETE');
+  assert.strictEqual(
+    ctx.calls.options.uri,
+    'https://gitlab.example.com/api/v4/projects/1/merge_requests/20/notes/7'
+  );
+});
+
+test('labels add builds correct body', async () => {
+  const node = new GitlabExtended();
+  const ctx = createContext({ resource: 'mergeRequest', operation: 'labels', mergeRequestIid: 21, labels: 'bug,urgent', labelAction: 'add' });
+  await node.execute.call(ctx);
+  assert.strictEqual(ctx.calls.options.method, 'PUT');
+  assert.strictEqual(
+    ctx.calls.options.uri,
+    'https://gitlab.example.com/api/v4/projects/1/merge_requests/21'
+  );
+  assert.deepStrictEqual(ctx.calls.options.body, { add_labels: 'bug,urgent' });
+});
+
+test('labels remove builds correct body', async () => {
+  const node = new GitlabExtended();
+  const ctx = createContext({ resource: 'mergeRequest', operation: 'labels', mergeRequestIid: 22, labels: 'bug,urgent', labelAction: 'remove' });
+  await node.execute.call(ctx);
+  assert.strictEqual(ctx.calls.options.method, 'PUT');
+  assert.strictEqual(
+    ctx.calls.options.uri,
+    'https://gitlab.example.com/api/v4/projects/1/merge_requests/22'
+  );
+  assert.deepStrictEqual(ctx.calls.options.body, { remove_labels: 'bug,urgent' });
+});
+
+test('postDiscussionNote throws if discussionId missing when not starting discussion', async () => {
+  const node = new GitlabExtended();
+  const ctx = createContext({
+    resource: 'mergeRequest',
+    operation: 'postDiscussionNote',
+    mergeRequestIid: 23,
+    body: 'hi',
+    startDiscussion: false,
+    discussionId: '',
+  });
+  await assert.rejects(
+    () => node.execute.call(ctx),
+    /Discussion ID must be provided when replying to a discussion./
+  );
+});
+
+test('postDiscussionNote throws on negative oldLine', async () => {
+  const node = new GitlabExtended();
+  const ctx = createContext({
+    resource: 'mergeRequest',
+    operation: 'postDiscussionNote',
+    mergeRequestIid: 24,
+    body: 'bad',
+    startDiscussion: true,
+    asSuggestion: true,
+    positionType: 'text',
+    newPath: 'a.ts',
+    oldPath: 'a.ts',
+    newLine: 5,
+    baseSha: '111',
+    headSha: '222',
+    startSha: '333',
+    oldLine: -1,
+  });
+  await assert.rejects(
+    () => node.execute.call(ctx),
+    /The "oldLine" parameter must be a non-negative number./
+  );
+});


### PR DESCRIPTION
## Summary
- expand merge request tests for additional operations and error cases

## Testing
- `npm test`