### PR TITLE
feat: include full GitLab response in errors

### DIFF
--- a/nodes/GitlabExtended/GenericFunctions.ts
+++ b/nodes/GitlabExtended/GenericFunctions.ts
@@ -54,17 +54,19 @@ export async function gitlabApiRequest(
         }
         const baseUrl = `${host}/api/v4`;
 
-        try {
-                options.uri = `${baseUrl}${endpoint}`;
-                return await this.helpers.requestWithAuthentication.call(this, 'gitlabExtendedApi', options);
-        } catch (error) {
-                let description;
-                const responseData = (error as JsonObject as { response?: { data?: unknown } }).response?.data;
-                if (responseData !== undefined) {
-                        description = typeof responseData === 'string' ? responseData : JSON.stringify(responseData);
-                }
-                throw new NodeApiError(this.getNode(), error as JsonObject, { description });
-        }
+       try {
+               options.uri = `${baseUrl}${endpoint}`;
+               return await this.helpers.requestWithAuthentication.call(this, 'gitlabExtendedApi', options);
+       } catch (error) {
+               let description;
+               let message;
+               const responseData = (error as JsonObject as { response?: { data?: unknown } }).response?.data;
+               if (responseData !== undefined) {
+                       description = typeof responseData === 'string' ? responseData : JSON.stringify(responseData);
+                       message = description;
+               }
+               throw new NodeApiError(this.getNode(), error as JsonObject, { message, description });
+       }
 }
 
 /**


### PR DESCRIPTION
## Summary
- show full GitLab error responses when API calls fail

## Testing
- `npm test`