### PR TITLE
Fix credential check using /user endpoint

### DIFF
--- a/credentials/GitlabExtendedApi.credentials.ts
+++ b/credentials/GitlabExtendedApi.credentials.ts
@@ -65,10 +65,10 @@ export class GitlabExtendedApi implements ICredentialType {
 		},
 	};
 
-	test: ICredentialTestRequest = {
-		request: {
-			baseURL: '={{$credentials.server.replace(new RegExp("/$"), "") + "/api/v4" }}',
-			url: '/personal_access_tokens/self',
-		},
-	};
+        test: ICredentialTestRequest = {
+                request: {
+                        baseURL: '={{$credentials.server.replace(new RegExp("/$"), "") + "/api/v4" }}',
+                        url: '/user',
+                },
+        };
 }

--- a/tests/gitlabExtendedApiCredentials.test.js
+++ b/tests/gitlabExtendedApiCredentials.test.js
@@ -3,14 +3,15 @@ import test from 'node:test';
 import { GitlabExtendedApi } from '../dist/credentials/GitlabExtendedApi.credentials.js';
 
 test('Gitlab Extended API credentials expose expected fields', () => {
-	const cred = new GitlabExtendedApi();
-	assert.strictEqual(cred.name, 'gitlabExtendedApi');
-	const names = cred.properties.map((p) => p.name);
-	assert.deepStrictEqual(names, [
-		'server',
-		'accessToken',
-		'projectOwner',
-		'projectName',
-		'projectId',
-	]);
+        const cred = new GitlabExtendedApi();
+        assert.strictEqual(cred.name, 'gitlabExtendedApi');
+        const names = cred.properties.map((p) => p.name);
+        assert.deepStrictEqual(names, [
+                'server',
+                'accessToken',
+                'projectOwner',
+                'projectName',
+                'projectId',
+        ]);
+        assert.strictEqual(cred.test.request.url, '/user');
 });


### PR DESCRIPTION
## Summary
- verify GitLab credentials via `/user` endpoint
- test credential initialization for new check

## Testing
- `npm test`