### PR TITLE
Add project credential validation helper

### DIFF
--- a/nodes/GitlabExtended/GenericFunctions.ts
+++ b/nodes/GitlabExtended/GenericFunctions.ts
@@ -120,6 +120,25 @@ export function buildProjectBase(cred: IDataObject): string {
 }
 
 /**
+ * Ensure credentials contain enough information to identify a project.
+ */
+export function assertValidProjectCredentials(
+        this: IHookFunctions | IExecuteFunctions,
+        cred: IDataObject,
+): void {
+        if (!cred.projectId) {
+                const owner = cred.projectOwner as string;
+                const name = cred.projectName as string;
+                if (!owner || !name) {
+                        throw new NodeOperationError(
+                                this.getNode(),
+                                'Credentials must include either projectId or both projectOwner and projectName',
+                        );
+                }
+        }
+}
+
+/**
  * Get a merge request discussion by ID
  *
  * @param {IHookFunctions | IExecuteFunctions} this - The context of the function

--- a/nodes/GitlabExtended/GitlabExtended.node.ts
+++ b/nodes/GitlabExtended/GitlabExtended.node.ts
@@ -8,7 +8,12 @@ import type {
 } from 'n8n-workflow';
 import { NodeConnectionType, NodeOperationError } from 'n8n-workflow';
 
-import { gitlabApiRequest, gitlabApiRequestAllItems, buildProjectBase } from './GenericFunctions';
+import {
+        gitlabApiRequest,
+        gitlabApiRequestAllItems,
+        buildProjectBase,
+        assertValidProjectCredentials,
+} from './GenericFunctions';
 import { requirePositive } from './validators';
 import { handleBranch } from './resources/branch';
 import { handlePipeline } from './resources/pipeline';
@@ -958,18 +963,8 @@ export class GitlabExtended implements INodeType {
 		const returnData: INodeExecutionData[] = [];
 		const operation = this.getNodeParameter('operation', 0);
 		const resource = this.getNodeParameter('resource', 0);
-		const credential = await this.getCredentials('gitlabExtendedApi');
-
-		if (!credential.projectId) {
-			const owner = credential.projectOwner as string;
-			const name = credential.projectName as string;
-			if (!owner || !name) {
-				throw new NodeOperationError(
-					this.getNode(),
-					'Credentials must include either projectId or both projectOwner and projectName',
-				);
-			}
-		}
+                const credential = await this.getCredentials('gitlabExtendedApi');
+                assertValidProjectCredentials.call(this, credential);
 
 		const base = buildProjectBase(credential);
 

--- a/nodes/GitlabExtended/resources/branch.ts
+++ b/nodes/GitlabExtended/resources/branch.ts
@@ -5,7 +5,12 @@ import type {
 	IHttpRequestMethods,
 } from 'n8n-workflow';
 import { NodeOperationError } from 'n8n-workflow';
-import { gitlabApiRequest, gitlabApiRequestAllItems, buildProjectBase } from '../GenericFunctions';
+import {
+        gitlabApiRequest,
+        gitlabApiRequestAllItems,
+        buildProjectBase,
+        assertValidProjectCredentials,
+} from '../GenericFunctions';
 import { requireString } from '../validators';
 
 /**
@@ -21,18 +26,8 @@ export async function handleBranch(
 	itemIndex: number,
 ): Promise<INodeExecutionData[]> {
 	const operation = this.getNodeParameter('operation', itemIndex);
-	const credential = await this.getCredentials('gitlabExtendedApi');
-
-	if (!credential.projectId) {
-		const owner = credential.projectOwner as string;
-		const name = credential.projectName as string;
-		if (!owner || !name) {
-			throw new NodeOperationError(
-				this.getNode(),
-				'Credentials must include either projectId or both projectOwner and projectName',
-			);
-		}
-	}
+        const credential = await this.getCredentials('gitlabExtendedApi');
+        assertValidProjectCredentials.call(this, credential);
 
 	const base = buildProjectBase(credential);
 

--- a/nodes/GitlabExtended/resources/file.ts
+++ b/nodes/GitlabExtended/resources/file.ts
@@ -5,7 +5,12 @@ import type {
         IHttpRequestMethods,
 } from 'n8n-workflow';
 import { NodeOperationError } from 'n8n-workflow';
-import { gitlabApiRequest, gitlabApiRequestAllItems, buildProjectBase } from '../GenericFunctions';
+import {
+        gitlabApiRequest,
+        gitlabApiRequestAllItems,
+        buildProjectBase,
+        assertValidProjectCredentials,
+} from '../GenericFunctions';
 
 export async function handleFile(
         this: IExecuteFunctions,
@@ -13,17 +18,7 @@ export async function handleFile(
 ): Promise<INodeExecutionData[]> {
         const operation = this.getNodeParameter('operation', itemIndex);
         const credential = await this.getCredentials('gitlabExtendedApi');
-
-        if (!credential.projectId) {
-                const owner = credential.projectOwner as string;
-                const name = credential.projectName as string;
-                if (!owner || !name) {
-                        throw new NodeOperationError(
-                                this.getNode(),
-                                'Credentials must include either projectId or both projectOwner and projectName',
-                        );
-                }
-        }
+        assertValidProjectCredentials.call(this, credential);
 
         const base = buildProjectBase(credential);
 

--- a/nodes/GitlabExtended/resources/mergeRequest.ts
+++ b/nodes/GitlabExtended/resources/mergeRequest.ts
@@ -5,7 +5,12 @@ import type {
         IHttpRequestMethods,
 } from 'n8n-workflow';
 import { NodeOperationError } from 'n8n-workflow';
-import { gitlabApiRequest, gitlabApiRequestAllItems, buildProjectBase } from '../GenericFunctions';
+import {
+        gitlabApiRequest,
+        gitlabApiRequestAllItems,
+        buildProjectBase,
+        assertValidProjectCredentials,
+} from '../GenericFunctions';
 import { requirePositive } from '../validators';
 
 export async function handleMergeRequest(
@@ -14,17 +19,7 @@ export async function handleMergeRequest(
 ): Promise<INodeExecutionData[]> {
         const operation = this.getNodeParameter('operation', itemIndex);
         const credential = await this.getCredentials('gitlabExtendedApi');
-
-        if (!credential.projectId) {
-                const owner = credential.projectOwner as string;
-                const name = credential.projectName as string;
-                if (!owner || !name) {
-                        throw new NodeOperationError(
-                                this.getNode(),
-                                'Credentials must include either projectId or both projectOwner and projectName',
-                        );
-                }
-        }
+        assertValidProjectCredentials.call(this, credential);
 
         const base = buildProjectBase(credential);
 

--- a/nodes/GitlabExtended/resources/pipeline.ts
+++ b/nodes/GitlabExtended/resources/pipeline.ts
@@ -5,7 +5,12 @@ import type {
         IHttpRequestMethods,
 } from 'n8n-workflow';
 import { NodeOperationError } from 'n8n-workflow';
-import { gitlabApiRequest, gitlabApiRequestAllItems, buildProjectBase } from '../GenericFunctions';
+import {
+        gitlabApiRequest,
+        gitlabApiRequestAllItems,
+        buildProjectBase,
+        assertValidProjectCredentials,
+} from '../GenericFunctions';
 import { requirePositive } from '../validators';
 
 export async function handlePipeline(
@@ -14,17 +19,7 @@ export async function handlePipeline(
 ): Promise<INodeExecutionData[]> {
         const operation = this.getNodeParameter('operation', itemIndex);
         const credential = await this.getCredentials('gitlabExtendedApi');
-
-        if (!credential.projectId) {
-                const owner = credential.projectOwner as string;
-                const name = credential.projectName as string;
-                if (!owner || !name) {
-                        throw new NodeOperationError(
-                                this.getNode(),
-                                'Credentials must include either projectId or both projectOwner and projectName',
-                        );
-                }
-        }
+        assertValidProjectCredentials.call(this, credential);
 
         const base = buildProjectBase(credential);
 


### PR DESCRIPTION
## Summary
- introduce `assertValidProjectCredentials` to check project info in credentials
- reuse the new helper in branch, file, pipeline, merge request, and execute logic

## Testing
- `npm test`