### PR TITLE
Refactor tests to share createContext helper

### DIFF
--- a/tests/fileOperations.test.js
+++ b/tests/fileOperations.test.js
@@ -1,31 +1,7 @@
 import assert from 'node:assert';
 import test from 'node:test';
 import { GitlabExtended } from '../dist/nodes/GitlabExtended/GitlabExtended.node.js';
-
-function createContext(params) {
-  const calls = {};
-  return {
-    calls,
-    getInputData() {
-      return [{ json: {} }];
-    },
-    getNodeParameter(name) {
-      return params[name];
-    },
-    async getCredentials() {
-      return { server: 'https://gitlab.example.com', accessToken: 't', projectId: 1 };
-    },
-    helpers: {
-      async requestWithAuthentication(name, options) {
-        calls.options = options;
-        return {};
-      },
-      constructExecutionMetaData(data) { return data; },
-      returnJsonArray(data) { return [{ json: data }]; },
-    },
-    getNode() { return {}; },
-  };
-}
+import createContext from './helpers/createContext.js';
 
 test('create builds correct endpoint and body', async () => {
   const node = new GitlabExtended();

--- a/tests/gitlabApiRequestValidation.test.js
+++ b/tests/gitlabApiRequestValidation.test.js
@@ -2,26 +2,18 @@ import assert from 'node:assert';
 import test from 'node:test';
 import { gitlabApiRequest } from '../dist/nodes/GitlabExtended/GenericFunctions.js';
 import { NodeOperationError } from 'n8n-workflow/dist/errors/index.js';
-
-function createContext(cred) {
-  return {
-    async getCredentials(name) {
-      if (name !== 'gitlabExtendedApi') throw new Error('Unexpected credentials name');
-      return cred;
-    },
-    helpers: {
-      async requestWithAuthentication() {
-        throw new Error('Should not reach request');
-      },
-    },
-    getNode() {
-      return {};
-    },
-  };
-}
+import createContext from './helpers/createContext.js';
 
 test('gitlabApiRequest throws when server URL is missing', async () => {
-  const ctx = createContext({ server: '', accessToken: 'token' });
+  const creds = { server: '', accessToken: 'token' };
+  const ctx = createContext({});
+  ctx.getCredentials = async (name) => {
+    if (name !== 'gitlabExtendedApi') throw new Error('Unexpected credentials name');
+    return creds;
+  };
+  ctx.helpers.requestWithAuthentication = async () => {
+    throw new Error('Should not reach request');
+  };
   await assert.rejects(
     () => gitlabApiRequest.call(ctx, 'GET', '/foo', {}, undefined),
     (err) => {
@@ -33,7 +25,15 @@ test('gitlabApiRequest throws when server URL is missing', async () => {
 });
 
 test('gitlabApiRequest throws when server is undefined', async () => {
-  const ctx = createContext({ accessToken: 'token' });
+  const creds = { accessToken: 'token' };
+  const ctx = createContext({});
+  ctx.getCredentials = async (name) => {
+    if (name !== 'gitlabExtendedApi') throw new Error('Unexpected credentials name');
+    return creds;
+  };
+  ctx.helpers.requestWithAuthentication = async () => {
+    throw new Error('Should not reach request');
+  };
   await assert.rejects(
     () => gitlabApiRequest.call(ctx, 'GET', '/foo', {}, undefined),
     (err) => {
@@ -45,7 +45,15 @@ test('gitlabApiRequest throws when server is undefined', async () => {
 });
 
 test('gitlabApiRequest throws when access token is missing', async () => {
-  const ctx = createContext({ server: 'https://gitlab.example.com', accessToken: '' });
+  const creds = { server: 'https://gitlab.example.com', accessToken: '' };
+  const ctx = createContext({});
+  ctx.getCredentials = async (name) => {
+    if (name !== 'gitlabExtendedApi') throw new Error('Unexpected credentials name');
+    return creds;
+  };
+  ctx.helpers.requestWithAuthentication = async () => {
+    throw new Error('Should not reach request');
+  };
   await assert.rejects(
     () => gitlabApiRequest.call(ctx, 'GET', '/foo', {}, undefined),
     (err) => {

--- a/tests/groupOperations.test.js
+++ b/tests/groupOperations.test.js
@@ -1,28 +1,17 @@
 import assert from 'node:assert';
 import test from 'node:test';
 import { GitlabExtended } from '../dist/nodes/GitlabExtended/GitlabExtended.node.js';
-
-function createContext(params) {
-  const calls = {};
-  return {
-    calls,
-    getInputData() { return [{ json: {} }]; },
-    getNodeParameter(name) { return params[name]; },
-    async getCredentials() {
-      return { server: 'https://gitlab.example.com', accessToken: 't', projectId: 1 };
-    },
-    helpers: {
-      async requestWithAuthentication(name, options) { calls.name = name; calls.options = options; return {}; },
-      constructExecutionMetaData(data) { return data; },
-      returnJsonArray(data) { return [{ json: data }]; },
-    },
-    getNode() { return {}; },
-  };
-}
+import createContext from './helpers/createContext.js';
 
 test('create builds correct endpoint and body', async () => {
   const node = new GitlabExtended();
-  const ctx = createContext({ resource: 'group', operation: 'create', groupName: 'Dev', groupPath: 'dev' });
+  const params = { resource: 'group', operation: 'create', groupName: 'Dev', groupPath: 'dev' };
+  const ctx = createContext(params);
+  ctx.helpers.requestWithAuthentication = async (name, options) => {
+    ctx.calls.name = name;
+    ctx.calls.options = options;
+    return {};
+  };
   await node.execute.call(ctx);
   assert.strictEqual(ctx.calls.name, 'gitlabExtendedApi');
   assert.strictEqual(ctx.calls.options.method, 'POST');
@@ -32,7 +21,13 @@ test('create builds correct endpoint and body', async () => {
 
 test('get builds correct endpoint', async () => {
   const node = new GitlabExtended();
-  const ctx = createContext({ resource: 'group', operation: 'get', groupId: 5 });
+  const params = { resource: 'group', operation: 'get', groupId: 5 };
+  const ctx = createContext(params);
+  ctx.helpers.requestWithAuthentication = async (name, options) => {
+    ctx.calls.name = name;
+    ctx.calls.options = options;
+    return {};
+  };
   await node.execute.call(ctx);
   assert.strictEqual(ctx.calls.options.method, 'GET');
   assert.strictEqual(ctx.calls.options.uri, 'https://gitlab.example.com/api/v4/groups/5');
@@ -40,7 +35,13 @@ test('get builds correct endpoint', async () => {
 
 test('delete builds correct endpoint', async () => {
   const node = new GitlabExtended();
-  const ctx = createContext({ resource: 'group', operation: 'delete', groupId: 7 });
+  const params = { resource: 'group', operation: 'delete', groupId: 7 };
+  const ctx = createContext(params);
+  ctx.helpers.requestWithAuthentication = async (name, options) => {
+    ctx.calls.name = name;
+    ctx.calls.options = options;
+    return {};
+  };
   await node.execute.call(ctx);
   assert.strictEqual(ctx.calls.options.method, 'DELETE');
   assert.strictEqual(ctx.calls.options.uri, 'https://gitlab.example.com/api/v4/groups/7');
@@ -48,7 +49,13 @@ test('delete builds correct endpoint', async () => {
 
 test('getMembers builds correct endpoint and respects limit', async () => {
   const node = new GitlabExtended();
-  const ctx = createContext({ resource: 'group', operation: 'getMembers', groupId: 9, returnAll: false, limit: 2 });
+  const params = { resource: 'group', operation: 'getMembers', groupId: 9, returnAll: false, limit: 2 };
+  const ctx = createContext(params);
+  ctx.helpers.requestWithAuthentication = async (name, options) => {
+    ctx.calls.name = name;
+    ctx.calls.options = options;
+    return {};
+  };
   await node.execute.call(ctx);
   assert.strictEqual(ctx.calls.options.method, 'GET');
   assert.strictEqual(ctx.calls.options.uri, 'https://gitlab.example.com/api/v4/groups/9/members');

--- a/tests/issueOperations.test.js
+++ b/tests/issueOperations.test.js
@@ -1,24 +1,7 @@
 import assert from 'node:assert';
 import test from 'node:test';
 import { GitlabExtended } from '../dist/nodes/GitlabExtended/GitlabExtended.node.js';
-
-function createContext(params) {
-  const calls = {};
-  return {
-    calls,
-    getInputData() { return [{ json: {} }]; },
-    getNodeParameter(name) { return params[name]; },
-    async getCredentials() {
-      return { server: 'https://gitlab.example.com', accessToken: 't', projectId: 1 };
-    },
-    helpers: {
-      async requestWithAuthentication(name, options) { calls.options = options; return {}; },
-      constructExecutionMetaData(data) { return data; },
-      returnJsonArray(data) { return [{ json: data }]; },
-    },
-    getNode() { return {}; },
-  };
-}
+import createContext from './helpers/createContext.js';
 
 test('update builds correct endpoint and body', async () => {
   const node = new GitlabExtended();

--- a/tests/pipelineGetJobs.test.js
+++ b/tests/pipelineGetJobs.test.js
@@ -1,33 +1,7 @@
 import assert from 'node:assert';
 import test from 'node:test';
 import { GitlabExtended } from '../dist/nodes/GitlabExtended/GitlabExtended.node.js';
-
-function createContext(params) {
-  const calls = {};
-  return {
-    calls,
-    getInputData() {
-      return [{ json: {} }];
-    },
-    getNodeParameter(name) {
-      return params[name];
-    },
-    async getCredentials() {
-      return { server: 'https://gitlab.example.com', accessToken: 't', projectId: 1 };
-    },
-    helpers: {
-      async requestWithAuthentication(name, options) {
-        calls.options = options;
-        return {};
-      },
-      constructExecutionMetaData(data) { return data; },
-      returnJsonArray(data) {
-        return [{ json: data }];
-      },
-    },
-    getNode() { return {}; },
-  };
-}
+import createContext from './helpers/createContext.js';
 
 test('getJobs builds correct endpoint and respects limit', async () => {
   const node = new GitlabExtended();

--- a/tests/pipelineOperations.test.js
+++ b/tests/pipelineOperations.test.js
@@ -1,31 +1,7 @@
 import assert from 'node:assert';
 import test from 'node:test';
 import { GitlabExtended } from '../dist/nodes/GitlabExtended/GitlabExtended.node.js';
-
-function createContext(params) {
-  const calls = {};
-  return {
-    calls,
-    getInputData() {
-      return [{ json: {} }];
-    },
-    getNodeParameter(name) {
-      return params[name];
-    },
-    async getCredentials() {
-      return { server: 'https://gitlab.example.com', accessToken: 't', projectId: 1 };
-    },
-    helpers: {
-      async requestWithAuthentication(name, options) {
-        calls.options = options;
-        return {};
-      },
-      constructExecutionMetaData(data) { return data; },
-      returnJsonArray(data) { return [{ json: data }]; },
-    },
-    getNode() { return {}; },
-  };
-}
+import createContext from './helpers/createContext.js';
 
 test('delete builds correct endpoint', async () => {
   const node = new GitlabExtended();

--- a/tests/projectOperations.test.js
+++ b/tests/projectOperations.test.js
@@ -1,37 +1,7 @@
 import assert from 'node:assert';
 import test from 'node:test';
 import { GitlabExtended } from '../dist/nodes/GitlabExtended/GitlabExtended.node.js';
-
-function createContext(params) {
-	const calls = {};
-	return {
-		calls,
-		getInputData() {
-			return [{ json: {} }];
-		},
-		getNodeParameter(name) {
-			return params[name];
-		},
-                async getCredentials() {
-                        return { server: 'https://gitlab.example.com', accessToken: 't', projectId: 1 };
-                },
-		helpers: {
-			async requestWithAuthentication(name, options) {
-				calls.options = options;
-				return {};
-			},
-			constructExecutionMetaData(data) {
-				return data;
-			},
-			returnJsonArray(data) {
-				return [{ json: data }];
-			},
-		},
-		getNode() {
-			return {};
-		},
-	};
-}
+import createContext from './helpers/createContext.js';
 
 test('get builds correct endpoint', async () => {
 	const node = new GitlabExtended();

--- a/tests/releaseOperations.test.js
+++ b/tests/releaseOperations.test.js
@@ -1,24 +1,7 @@
 import assert from 'node:assert';
 import test from 'node:test';
 import { GitlabExtended } from '../dist/nodes/GitlabExtended/GitlabExtended.node.js';
-
-function createContext(params) {
-  const calls = {};
-  return {
-    calls,
-    getInputData() { return [{ json: {} }]; },
-    getNodeParameter(name) { return params[name]; },
-    async getCredentials() {
-      return { server: 'https://gitlab.example.com', accessToken: 't', projectId: 1 };
-    },
-    helpers: {
-      async requestWithAuthentication(name, options) { calls.options = options; return {}; },
-      constructExecutionMetaData(data) { return data; },
-      returnJsonArray(data) { return [{ json: data }]; },
-    },
-    getNode() { return {}; },
-  };
-}
+import createContext from './helpers/createContext.js';
 
 test('create builds correct endpoint and body', async () => {
   const node = new GitlabExtended();

--- a/tests/tagOperations.test.js
+++ b/tests/tagOperations.test.js
@@ -1,24 +1,7 @@
 import assert from 'node:assert';
 import test from 'node:test';
 import { GitlabExtended } from '../dist/nodes/GitlabExtended/GitlabExtended.node.js';
-
-function createContext(params) {
-  const calls = {};
-  return {
-    calls,
-    getInputData() { return [{ json: {} }]; },
-    getNodeParameter(name) { return params[name]; },
-    async getCredentials() {
-      return { server: 'https://gitlab.example.com', accessToken: 't', projectId: 1 };
-    },
-    helpers: {
-      async requestWithAuthentication(name, options) { calls.options = options; return {}; },
-      constructExecutionMetaData(data) { return data; },
-      returnJsonArray(data) { return [{ json: data }]; },
-    },
-    getNode() { return {}; },
-  };
-}
+import createContext from './helpers/createContext.js';
 
 test('create builds correct endpoint and body', async () => {
   const node = new GitlabExtended();


### PR DESCRIPTION
## Summary
- reuse helper createContext across tests instead of duplicating
- override context functions where needed

## Testing
- `npm test`