### PR TITLE
Add coverage testing workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,14 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version: 22
           cache: 'npm'
       - run: npm ci
       - run: npm run lint
       - run: npm run format:check
       - run: npm run build
-      - run: npm test
+      - run: npm run test:coverage
+      - uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: coverage

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist
 npm-debug.log*
 yarn.lock
 .vscode/launch.json
+coverage/

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "lint": "eslint \"nodes/**/*.{ts,tsx}\" package.json",
     "lintfix": "eslint --ext .ts nodes credentials package.json --fix",
     "prepublishOnly": "npm run build && npm run lint -c .eslintrc.prepublish.js nodes package.json",
-    "test": "npm run build && node --test"
+    "test": "npm run build && node --test",
+    "test:coverage": "npm run build && node --test --coverage"
   },
   "files": [
     "dist"


### PR DESCRIPTION
## Summary
- add `test:coverage` npm script
- run coverage test in CI and upload artifact
- ignore coverage output
- update CI to use Node.js 22

## Testing
- `npm test`
