### PR TITLE
Add checkout and patch branch ops

### DIFF
--- a/nodes/GitlabExtended/GitlabExtended.node.ts
+++ b/nodes/GitlabExtended/GitlabExtended.node.ts
@@ -286,6 +286,15 @@ export class GitlabExtended implements INodeType {
 				description: 'Target branch to merge into',
 				default: '',
 			},
+                        {
+                                displayName: 'Patch',
+                                name: 'patch',
+                                type: 'string',
+                                required: true,
+                                displayOptions: { show: { resource: ['branch'], operation: ['applyPatch'] } },
+                                description: 'Patch text to apply',
+                                default: ''
+                        },
 			{
 				displayName: 'Developers Can Push',
 				name: 'developersCanPush',
@@ -310,7 +319,7 @@ export class GitlabExtended implements INodeType {
 				displayOptions: {
 					show: {
 						resource: ['branch', 'file', 'tag'],
-						operation: ['create', 'get', 'list'],
+						operation: ['create', 'get', 'list', 'checkout'],
 					},
 				},
 				description:

--- a/nodes/GitlabExtended/operations.ts
+++ b/nodes/GitlabExtended/operations.ts
@@ -7,6 +7,8 @@ export const branchOperations = {
 	protect: { name: 'Protect', value: 'protect', action: 'Protect a branch' },
 	rename: { name: 'Rename', value: 'rename', action: 'Rename a branch' },
 	unprotect: { name: 'Unprotect', value: 'unprotect', action: 'Unprotect a branch' },
+        checkout: { name: "Checkout", value: "checkout", action: "Checkout a branch archive" },
+        applyPatch: { name: "Apply Patch", value: "applyPatch", action: "Apply a patch" },
 } as const;
 
 export type BranchOperation = keyof typeof branchOperations;

--- a/nodes/GitlabExtended/resources/branch.ts
+++ b/nodes/GitlabExtended/resources/branch.ts
@@ -85,6 +85,21 @@ export async function handleBranch(
 		body.source_branch = branch;
 		body.target_branch = target;
 		endpoint = `${base}/repository/merges`;
+        } else if (operation === "checkout") {
+                requestMethod = "GET";
+                const ref = this.getNodeParameter("ref", itemIndex) as string;
+                requireString.call(this, ref, "ref", itemIndex);
+                qs.sha = ref;
+                endpoint = `${base}/repository/archive`;
+        } else if (operation === "applyPatch") {
+                requestMethod = "POST";
+                const branch = this.getNodeParameter("branch", itemIndex) as string;
+                const patch = this.getNodeParameter("patch", itemIndex) as string;
+                requireString.call(this, branch, "branch", itemIndex);
+                requireString.call(this, patch, "patch", itemIndex);
+                body.branch = branch;
+                body.patch = patch;
+                endpoint = `${base}/apply_patch`;
 	} else {
 		throw new NodeOperationError(this.getNode(), `The operation "${operation}" is not supported.`, {
 			itemIndex,

--- a/tests/branchOperations.test.js
+++ b/tests/branchOperations.test.js
@@ -155,3 +155,32 @@ test('delete builds correct endpoint', async () => {
     'https://gitlab.example.com/api/v4/projects/1/repository/branches/obsolete',
   );
 });
+
+test('checkout builds correct endpoint', async () => {
+  const node = new GitlabExtended();
+  const ctx = createContext({ resource: 'branch', operation: 'checkout', ref: 'main' });
+  await node.execute.call(ctx);
+  assert.strictEqual(ctx.calls.options.method, 'GET');
+  assert.strictEqual(
+    ctx.calls.options.uri,
+    'https://gitlab.example.com/api/v4/projects/1/repository/archive'
+  );
+  assert.strictEqual(ctx.calls.options.qs.sha, 'main');
+});
+
+test('applyPatch builds correct endpoint and body', async () => {
+  const node = new GitlabExtended();
+  const ctx = createContext({
+    resource: 'branch',
+    operation: 'applyPatch',
+    branch: 'main',
+    patch: 'diff --git a/a b/a',
+  });
+  await node.execute.call(ctx);
+  assert.strictEqual(ctx.calls.options.method, 'POST');
+  assert.strictEqual(
+    ctx.calls.options.uri,
+    'https://gitlab.example.com/api/v4/projects/1/apply_patch'
+  );
+  assert.deepStrictEqual(ctx.calls.options.body, { branch: 'main', patch: 'diff --git a/a b/a' });
+});


### PR DESCRIPTION
## Summary
- add `checkout` and `applyPatch` to branch operations
- support the new operations in the GitLab node
- handle new branch operations
- test the new branch operations

## Testing
- `npm test`