### PR TITLE
Add checkout and patch branch ops

### DIFF
--- a/nodes/GitlabExtended/GitlabExtended.node.ts
+++ b/nodes/GitlabExtended/GitlabExtended.node.ts
@@ -254,7 +254,17 @@ export class GitlabExtended implements INodeType {
 				displayOptions: {
 					show: {
 						resource: ['branch'],
-						operation: ['create', 'get', 'delete', 'rename', 'protect', 'unprotect', 'merge'],
+						operation: [
+							'create',
+							'get',
+							'delete',
+							'rename',
+							'protect',
+							'unprotect',
+							'merge',
+							'applyPatch',
+							'resetHard',
+						],
 					},
 				},
 				description: "Branch name, for example 'feature/login'",
@@ -287,6 +297,15 @@ export class GitlabExtended implements INodeType {
 				default: '',
 			},
 			{
+				displayName: 'Patch',
+				name: 'patch',
+				type: 'string',
+				required: true,
+				displayOptions: { show: { resource: ['branch'], operation: ['applyPatch'] } },
+				description: 'Patch text to apply',
+				default: '',
+			},
+			{
 				displayName: 'Developers Can Push',
 				name: 'developersCanPush',
 				type: 'boolean',
@@ -310,7 +329,7 @@ export class GitlabExtended implements INodeType {
 				displayOptions: {
 					show: {
 						resource: ['branch', 'file', 'tag'],
-						operation: ['create', 'get', 'list'],
+						operation: ['create', 'get', 'list', 'checkout', 'resetHard'],
 					},
 				},
 				description:

--- a/nodes/GitlabExtended/operations.ts
+++ b/nodes/GitlabExtended/operations.ts
@@ -7,6 +7,9 @@ export const branchOperations = {
 	protect: { name: 'Protect', value: 'protect', action: 'Protect a branch' },
 	rename: { name: 'Rename', value: 'rename', action: 'Rename a branch' },
 	unprotect: { name: 'Unprotect', value: 'unprotect', action: 'Unprotect a branch' },
+	checkout: { name: 'Checkout', value: 'checkout', action: 'Checkout a branch archive' },
+	applyPatch: { name: 'Apply Patch', value: 'applyPatch', action: 'Apply a patch' },
+	resetHard: { name: 'Reset Hard', value: 'resetHard', action: 'Reset branch hard' },
 } as const;
 
 export type BranchOperation = keyof typeof branchOperations;

--- a/nodes/GitlabExtended/resources/branch.ts
+++ b/nodes/GitlabExtended/resources/branch.ts
@@ -85,6 +85,30 @@ export async function handleBranch(
 		body.source_branch = branch;
 		body.target_branch = target;
 		endpoint = `${base}/repository/merges`;
+	} else if (operation === 'checkout') {
+		requestMethod = 'GET';
+		const ref = this.getNodeParameter('ref', itemIndex) as string;
+		requireString.call(this, ref, 'ref', itemIndex);
+		qs.sha = ref;
+		endpoint = `${base}/repository/archive`;
+	} else if (operation === 'applyPatch') {
+		requestMethod = 'POST';
+		const branch = this.getNodeParameter('branch', itemIndex) as string;
+		const patch = this.getNodeParameter('patch', itemIndex) as string;
+		requireString.call(this, branch, 'branch', itemIndex);
+		requireString.call(this, patch, 'patch', itemIndex);
+		body.branch = branch;
+		body.patch = patch;
+		endpoint = `${base}/apply_patch`;
+	} else if (operation === 'resetHard') {
+		requestMethod = 'POST';
+		const branch = this.getNodeParameter('branch', itemIndex) as string;
+		const ref = this.getNodeParameter('ref', itemIndex) as string;
+		requireString.call(this, branch, 'branch', itemIndex);
+		requireString.call(this, ref, 'ref', itemIndex);
+		body.reset_type = 'hard';
+		body.ref = ref;
+		endpoint = `${base}/repository/branches/${encodeURIComponent(branch)}/reset`;
 	} else {
 		throw new NodeOperationError(this.getNode(), `The operation "${operation}" is not supported.`, {
 			itemIndex,

--- a/tests/branchOperations.test.js
+++ b/tests/branchOperations.test.js
@@ -155,3 +155,50 @@ test('delete builds correct endpoint', async () => {
     'https://gitlab.example.com/api/v4/projects/1/repository/branches/obsolete',
   );
 });
+
+test('checkout builds correct endpoint', async () => {
+  const node = new GitlabExtended();
+  const ctx = createContext({ resource: 'branch', operation: 'checkout', ref: 'main' });
+  await node.execute.call(ctx);
+  assert.strictEqual(ctx.calls.options.method, 'GET');
+  assert.strictEqual(
+    ctx.calls.options.uri,
+    'https://gitlab.example.com/api/v4/projects/1/repository/archive'
+  );
+  assert.strictEqual(ctx.calls.options.qs.sha, 'main');
+});
+
+test('applyPatch builds correct endpoint and body', async () => {
+  const node = new GitlabExtended();
+  const ctx = createContext({
+    resource: 'branch',
+    operation: 'applyPatch',
+    branch: 'main',
+    patch: 'diff --git a/a b/a',
+  });
+  await node.execute.call(ctx);
+  assert.strictEqual(ctx.calls.options.method, 'POST');
+  assert.strictEqual(
+    ctx.calls.options.uri,
+    'https://gitlab.example.com/api/v4/projects/1/apply_patch'
+  );
+  assert.deepStrictEqual(ctx.calls.options.body, { branch: 'main', patch: 'diff --git a/a b/a' });
+});
+
+test('resetHard builds correct endpoint and body', async () => {
+  const node = new GitlabExtended();
+  const ctx = createContext({
+    resource: 'branch',
+    operation: 'resetHard',
+    branch: 'main',
+    ref: 'abc123',
+  });
+  await node.execute.call(ctx);
+  assert.strictEqual(ctx.calls.options.method, 'POST');
+  assert.strictEqual(
+    ctx.calls.options.uri,
+    'https://gitlab.example.com/api/v4/projects/1/repository/branches/main/reset',
+  );
+  assert.deepStrictEqual(ctx.calls.options.body, { reset_type: 'hard', ref: 'abc123' });
+});
+


### PR DESCRIPTION
## Summary
- add `checkout` and `applyPatch` to branch operations
- support the new operations in the GitLab node
- handle new branch operations
- add hard reset support for branches
- test the new branch operations

## Testing
- `npm run format:check`
- `npm test`
