### PR TITLE
Remove suggestion option from discussion notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,10 +167,9 @@ required for your chosen operation.
 | `discussionId`       | Discussion ID                                      |
 | `resolved`           | Whether a discussion is resolved                   |
 | `noteId`             | ID of a note (positive)                            |
-| `asSuggestion`       | Format note as suggestion                          |
-| `positionType`       | `text` or `image` suggestion                       |
-| `newPath`/`oldPath`  | File paths for suggestions                         |
-| `newLine`/`oldLine`  | Line numbers for suggestions                       |
+| `positionType`       | `text` or `image` position                         |
+| `newPath`/`oldPath`  | File paths for note position                       |
+| `newLine`/`oldLine`  | Line numbers for note position                     |
 | `baseSha`            | Base commit SHA                                    |
 | `headSha`            | Head commit SHA                                    |
 | `startSha`           | Start commit SHA                                   |

--- a/nodes/GitlabExtended/GitlabExtended.node.ts
+++ b/nodes/GitlabExtended/GitlabExtended.node.ts
@@ -21,11 +21,6 @@ import { handleFile } from './resources/file';
 import { handleMergeRequest } from './resources/mergeRequest';
 import { branchOperations } from './operations';
 
-// Define asSuggestionCondition
-const asSuggestionCondition = {
-	asSuggestion: [true],
-};
-
 export class GitlabExtended implements INodeType {
 	description: INodeTypeDescription = {
 		displayName: 'GitLab Extended',
@@ -757,19 +752,6 @@ export class GitlabExtended implements INodeType {
 				default: 1,
 			},
 			{
-				displayName: 'Post as Suggestion',
-				name: 'asSuggestion',
-				type: 'boolean',
-				displayOptions: {
-					show: {
-						resource: ['mergeRequest'],
-						operation: ['postDiscussionNote'],
-					},
-				},
-				description: 'Whether to format note as a suggestion',
-				default: false,
-			},
-			{
 				displayName: 'Position Type',
 				name: 'positionType',
 				type: 'options',
@@ -777,7 +759,6 @@ export class GitlabExtended implements INodeType {
 					show: {
 						resource: ['mergeRequest'],
 						operation: ['postDiscussionNote'],
-						...asSuggestionCondition,
 					},
 				},
 				options: [
@@ -790,12 +771,10 @@ export class GitlabExtended implements INodeType {
 				displayName: 'New Path',
 				name: 'newPath',
 				type: 'string',
-				required: true,
 				displayOptions: {
 					show: {
 						resource: ['mergeRequest'],
 						operation: ['postDiscussionNote'],
-						asSuggestion: [true],
 					},
 				},
 				description: 'Path to the new file',
@@ -805,12 +784,10 @@ export class GitlabExtended implements INodeType {
 				displayName: 'Old Path',
 				name: 'oldPath',
 				type: 'string',
-				required: true,
 				displayOptions: {
 					show: {
 						resource: ['mergeRequest'],
 						operation: ['postDiscussionNote'],
-						asSuggestion: [true],
 					},
 				},
 				description: 'Path to the old file',
@@ -820,12 +797,10 @@ export class GitlabExtended implements INodeType {
 				displayName: 'New Line',
 				name: 'newLine',
 				type: 'number',
-				required: true,
 				displayOptions: {
 					show: {
 						resource: ['mergeRequest'],
 						operation: ['postDiscussionNote'],
-						asSuggestion: [true],
 					},
 				},
 				description: 'Line number in the new file',
@@ -835,12 +810,10 @@ export class GitlabExtended implements INodeType {
 				displayName: 'Old Line',
 				name: 'oldLine',
 				type: 'number',
-				required: true,
 				displayOptions: {
 					show: {
 						resource: ['mergeRequest'],
 						operation: ['postDiscussionNote'],
-						asSuggestion: [true],
 					},
 				},
 				description: 'Line number in the old file',
@@ -850,12 +823,10 @@ export class GitlabExtended implements INodeType {
 				displayName: 'Base SHA',
 				name: 'baseSha',
 				type: 'string',
-				required: true,
 				displayOptions: {
 					show: {
 						resource: ['mergeRequest'],
 						operation: ['postDiscussionNote'],
-						asSuggestion: [true],
 					},
 				},
 				description: 'Base commit SHA',
@@ -865,12 +836,10 @@ export class GitlabExtended implements INodeType {
 				displayName: 'Head SHA',
 				name: 'headSha',
 				type: 'string',
-				required: true,
 				displayOptions: {
 					show: {
 						resource: ['mergeRequest'],
 						operation: ['postDiscussionNote'],
-						asSuggestion: [true],
 					},
 				},
 				description: 'Head commit SHA',
@@ -880,12 +849,10 @@ export class GitlabExtended implements INodeType {
 				displayName: 'Start SHA',
 				name: 'startSha',
 				type: 'string',
-				required: true,
 				displayOptions: {
 					show: {
 						resource: ['mergeRequest'],
 						operation: ['postDiscussionNote'],
-						asSuggestion: [true],
 					},
 				},
 				description: 'Start commit SHA',

--- a/nodes/GitlabExtended/resources/mergeRequest.ts
+++ b/nodes/GitlabExtended/resources/mergeRequest.ts
@@ -57,23 +57,30 @@ export async function handleMergeRequest(
 		const iid = this.getNodeParameter('mergeRequestIid', itemIndex) as number;
 		requirePositive.call(this, iid, 'mergeRequestIid', itemIndex);
 		const newDiscussion = this.getNodeParameter('startDiscussion', itemIndex, false);
-		const asSuggestion = this.getNodeParameter('asSuggestion', itemIndex, false) as boolean;
-		let note = this.getNodeParameter('body', itemIndex) as string;
-		if (asSuggestion) {
-			note = `\`\`\`suggestion:-0+0\n${note}\n\`\`\``;
-		}
+		const note = this.getNodeParameter('body', itemIndex) as string;
 		body.body = note;
-		if (asSuggestion) {
-			const positionType = this.getNodeParameter('positionType', itemIndex) as string;
-			const newPath = this.getNodeParameter('newPath', itemIndex) as string;
-			const oldPath = this.getNodeParameter('oldPath', itemIndex) as string;
-			const newLine = this.getNodeParameter('newLine', itemIndex) as number;
-			const baseSha = this.getNodeParameter('baseSha', itemIndex) as string;
-			const headSha = this.getNodeParameter('headSha', itemIndex) as string;
-			const startSha = this.getNodeParameter('startSha', itemIndex) as string;
 
+		const positionType = this.getNodeParameter('positionType', itemIndex, '') as string;
+		const newPath = this.getNodeParameter('newPath', itemIndex, '') as string;
+		const oldPath = this.getNodeParameter('oldPath', itemIndex, '') as string;
+		const newLine = this.getNodeParameter('newLine', itemIndex, 1) as number;
+		const baseSha = this.getNodeParameter('baseSha', itemIndex, '') as string;
+		const headSha = this.getNodeParameter('headSha', itemIndex, '') as string;
+		const startSha = this.getNodeParameter('startSha', itemIndex, '') as string;
+		const oldLine = this.getNodeParameter('oldLine', itemIndex, 0) as number;
+
+		const hasPosition =
+			newPath !== '' && oldPath !== '' && baseSha !== '' && headSha !== '' && startSha !== '';
+
+		if (hasPosition) {
+			if (oldLine < 0) {
+				throw new NodeOperationError(
+					this.getNode(),
+					'The "oldLine" parameter must be a non-negative number.',
+				);
+			}
 			const position: IDataObject = {
-				position_type: positionType,
+				position_type: positionType || 'text',
 				new_path: newPath,
 				old_path: oldPath,
 				new_line: newLine,
@@ -81,13 +88,6 @@ export async function handleMergeRequest(
 				head_sha: headSha,
 				start_sha: startSha,
 			};
-			const oldLine = this.getNodeParameter('oldLine', itemIndex, 0) as number;
-			if (oldLine < 0) {
-				throw new NodeOperationError(
-					this.getNode(),
-					'The "oldLine" parameter must be a non-negative number.',
-				);
-			}
 			if (oldLine !== 0) {
 				position.old_line = oldLine;
 			}

--- a/tests/mergeRequestOperations.test.js
+++ b/tests/mergeRequestOperations.test.js
@@ -79,7 +79,7 @@ test('reopen builds correct endpoint', async () => {
   assert.deepStrictEqual(ctx.calls.options.body, { state_event: 'reopen' });
 });
 
-test('postDiscussionNote works without suggestion parameters', async () => {
+test('postDiscussionNote works without position parameters', async () => {
   const node = new GitlabExtended();
   const ctx = createTrackedContext({
     resource: 'mergeRequest',
@@ -95,10 +95,9 @@ test('postDiscussionNote works without suggestion parameters', async () => {
     'https://gitlab.example.com/api/v4/projects/1/merge_requests/11/discussions'
   );
   assert.deepStrictEqual(ctx.calls.options.body, { body: 'hello' });
-  assert.ok(!ctx.calls.params.includes('positionType'));
 });
 
-test('postDiscussionNote builds suggestion with position', async () => {
+test('postDiscussionNote builds note with position', async () => {
   const node = new GitlabExtended();
   const ctx = createTrackedContext({
     resource: 'mergeRequest',
@@ -106,7 +105,6 @@ test('postDiscussionNote builds suggestion with position', async () => {
     mergeRequestIid: 12,
     body: 'change',
     startDiscussion: true,
-    asSuggestion: true,
     positionType: 'text',
     newPath: 'a.ts',
     oldPath: 'a.ts',
@@ -123,7 +121,7 @@ test('postDiscussionNote builds suggestion with position', async () => {
     'https://gitlab.example.com/api/v4/projects/1/merge_requests/12/discussions'
   );
   assert.deepStrictEqual(ctx.calls.options.body, {
-    body: '```suggestion:-0+0\nchange\n```',
+    body: 'change',
     position: {
       position_type: 'text',
       new_path: 'a.ts',
@@ -365,7 +363,6 @@ test('postDiscussionNote throws on negative oldLine', async () => {
     mergeRequestIid: 24,
     body: 'bad',
     startDiscussion: true,
-    asSuggestion: true,
     positionType: 'text',
     newPath: 'a.ts',
     oldPath: 'a.ts',


### PR DESCRIPTION
## Summary
- post a discussion note without the suggestion toggle
- update merge request docs for new parameters
- adjust tests for new behaviour

## Testing
- `npm run format:check`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6840b88898e4832ba16ff365d3fa020b