### PR TITLE
Make diff note line numbers optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ required for your chosen operation.
 | `noteId`             | ID of a note (positive)                            |
 | `positionType`       | `text` or `image` position                         |
 | `newPath`/`oldPath`  | File paths for note position                       |
-| `newLine`/`oldLine`  | Line numbers for note position                     |
+| `newLine`/`oldLine`  | Optional line numbers for note position           |
 | `baseSha`            | Base commit SHA                                    |
 | `headSha`            | Head commit SHA                                    |
 | `startSha`           | Start commit SHA                                   |

--- a/nodes/GitlabExtended/GitlabExtended.node.ts
+++ b/nodes/GitlabExtended/GitlabExtended.node.ts
@@ -804,7 +804,7 @@ export class GitlabExtended implements INodeType {
 					},
 				},
 				description: 'Line number in the new file',
-				default: 1,
+				default: null,
 			},
 			{
 				displayName: 'Old Line',
@@ -817,7 +817,7 @@ export class GitlabExtended implements INodeType {
 					},
 				},
 				description: 'Line number in the old file',
-				default: 0,
+				default: null,
 			},
 			{
 				displayName: 'Base SHA',

--- a/nodes/GitlabExtended/resources/mergeRequest.ts
+++ b/nodes/GitlabExtended/resources/mergeRequest.ts
@@ -63,17 +63,17 @@ export async function handleMergeRequest(
 		const positionType = this.getNodeParameter('positionType', itemIndex, '') as string;
 		const newPath = this.getNodeParameter('newPath', itemIndex, '') as string;
 		const oldPath = this.getNodeParameter('oldPath', itemIndex, '') as string;
-		const newLine = this.getNodeParameter('newLine', itemIndex, 1) as number;
+		const newLine = this.getNodeParameter('newLine', itemIndex, null) as number | null;
 		const baseSha = this.getNodeParameter('baseSha', itemIndex, '') as string;
 		const headSha = this.getNodeParameter('headSha', itemIndex, '') as string;
 		const startSha = this.getNodeParameter('startSha', itemIndex, '') as string;
-		const oldLine = this.getNodeParameter('oldLine', itemIndex, 0) as number;
+		const oldLine = this.getNodeParameter('oldLine', itemIndex, null) as number | null;
 
 		const hasPosition =
 			newPath !== '' && oldPath !== '' && baseSha !== '' && headSha !== '' && startSha !== '';
 
 		if (hasPosition) {
-			if (oldLine < 0) {
+			if (oldLine !== null && oldLine < 0) {
 				throw new NodeOperationError(
 					this.getNode(),
 					'The "oldLine" parameter must be a non-negative number.',
@@ -83,12 +83,14 @@ export async function handleMergeRequest(
 				position_type: positionType || 'text',
 				new_path: newPath,
 				old_path: oldPath,
-				new_line: newLine,
 				base_sha: baseSha,
 				head_sha: headSha,
 				start_sha: startSha,
 			};
-			if (oldLine !== 0) {
+			if (newLine !== null) {
+				position.new_line = newLine;
+			}
+			if (oldLine !== null && oldLine !== 0) {
 				position.old_line = oldLine;
 			}
 			body.position = position;

--- a/tests/mergeRequestOperations.test.js
+++ b/tests/mergeRequestOperations.test.js
@@ -136,6 +136,35 @@ test('postDiscussionNote builds note with position', async () => {
   assert.ok(ctx.calls.params.includes('positionType'));
 });
 
+test('postDiscussionNote allows omitting line numbers', async () => {
+  const node = new GitlabExtended();
+  const ctx = createTrackedContext({
+    resource: 'mergeRequest',
+    operation: 'postDiscussionNote',
+    mergeRequestIid: 13,
+    body: 'nolines',
+    startDiscussion: true,
+    positionType: 'text',
+    newPath: 'a.ts',
+    oldPath: 'a.ts',
+    baseSha: '111',
+    headSha: '222',
+    startSha: '333',
+  });
+  await node.execute.call(ctx);
+  assert.deepStrictEqual(ctx.calls.options.body, {
+    body: 'nolines',
+    position: {
+      position_type: 'text',
+      new_path: 'a.ts',
+      old_path: 'a.ts',
+      base_sha: '111',
+      head_sha: '222',
+      start_sha: '333',
+    },
+  });
+});
+
 test('get builds correct endpoint', async () => {
   const node = new GitlabExtended();
   const ctx = createTrackedContext({ resource: 'mergeRequest', operation: 'get', mergeRequestIid: 1 });


### PR DESCRIPTION
## Summary
- make `newLine` and `oldLine` optional when creating merge request notes
- handle null line numbers in the merge request helper
- document new optional behaviour
- test posting a discussion note without line numbers

## Testing
- `npm run format:check`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6840f45dc118832ba8dfbe3e6f1bf03c