### PR TITLE
Add GitLab diff note line range support

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,12 @@ required for your chosen operation.
 | `positionType`       | `text` or `image` position                         |
 | `newPath`/`oldPath`  | File paths for note position                       |
 | `newLine`/`oldLine`  | Optional line numbers for note position           |
+| `lineRangeStartLineCode` | Line code for the start line of a multiline note |
+| `lineRangeStartType` | `new` or `old` start line type |
+| `lineRangeStartOldLine`/`lineRangeStartNewLine` | Optional line numbers for the start line |
+| `lineRangeEndLineCode` | Line code for the end line of a multiline note |
+| `lineRangeEndType` | `new` or `old` end line type |
+| `lineRangeEndOldLine`/`lineRangeEndNewLine` | Optional line numbers for the end line |
 | `baseSha`            | Base commit SHA                                    |
 | `headSha`            | Head commit SHA                                    |
 | `startSha`           | Start commit SHA                                   |

--- a/nodes/GitlabExtended/GitlabExtended.node.ts
+++ b/nodes/GitlabExtended/GitlabExtended.node.ts
@@ -831,6 +831,118 @@ export class GitlabExtended implements INodeType {
 				default: null,
 			},
 			{
+				displayName: 'Line Range Start Line Code',
+				name: 'lineRangeStartLineCode',
+				type: 'string',
+				displayOptions: {
+					show: {
+						resource: ['mergeRequest'],
+						operation: ['postDiscussionNote'],
+					},
+				},
+				description: 'Line code for the start of a multiline note',
+				default: '',
+			},
+			{
+				displayName: 'Line Range Start Type',
+				name: 'lineRangeStartType',
+				type: 'options',
+				displayOptions: {
+					show: {
+						resource: ['mergeRequest'],
+						operation: ['postDiscussionNote'],
+					},
+				},
+				options: [
+					{ name: 'New', value: 'new' },
+					{ name: 'Old', value: 'old' },
+				],
+				description: 'Use `new` for lines added by this commit, otherwise `old`',
+				default: 'new',
+			},
+			{
+				displayName: 'Line Range Start Old Line',
+				name: 'lineRangeStartOldLine',
+				type: 'number',
+				displayOptions: {
+					show: {
+						resource: ['mergeRequest'],
+						operation: ['postDiscussionNote'],
+					},
+				},
+				description: 'Old line number of the start line',
+				default: null,
+			},
+			{
+				displayName: 'Line Range Start New Line',
+				name: 'lineRangeStartNewLine',
+				type: 'number',
+				displayOptions: {
+					show: {
+						resource: ['mergeRequest'],
+						operation: ['postDiscussionNote'],
+					},
+				},
+				description: 'New line number of the start line',
+				default: null,
+			},
+			{
+				displayName: 'Line Range End Line Code',
+				name: 'lineRangeEndLineCode',
+				type: 'string',
+				displayOptions: {
+					show: {
+						resource: ['mergeRequest'],
+						operation: ['postDiscussionNote'],
+					},
+				},
+				description: 'Line code for the end of a multiline note',
+				default: '',
+			},
+			{
+				displayName: 'Line Range End Type',
+				name: 'lineRangeEndType',
+				type: 'options',
+				displayOptions: {
+					show: {
+						resource: ['mergeRequest'],
+						operation: ['postDiscussionNote'],
+					},
+				},
+				options: [
+					{ name: 'New', value: 'new' },
+					{ name: 'Old', value: 'old' },
+				],
+				description: 'Use `new` for lines added by this commit, otherwise `old`',
+				default: 'new',
+			},
+			{
+				displayName: 'Line Range End Old Line',
+				name: 'lineRangeEndOldLine',
+				type: 'number',
+				displayOptions: {
+					show: {
+						resource: ['mergeRequest'],
+						operation: ['postDiscussionNote'],
+					},
+				},
+				description: 'Old line number of the end line',
+				default: null,
+			},
+			{
+				displayName: 'Line Range End New Line',
+				name: 'lineRangeEndNewLine',
+				type: 'number',
+				displayOptions: {
+					show: {
+						resource: ['mergeRequest'],
+						operation: ['postDiscussionNote'],
+					},
+				},
+				description: 'New line number of the end line',
+				default: null,
+			},
+			{
 				displayName: 'Base SHA',
 				name: 'baseSha',
 				type: 'string',

--- a/nodes/GitlabExtended/resources/mergeRequest.ts
+++ b/nodes/GitlabExtended/resources/mergeRequest.ts
@@ -72,6 +72,34 @@ export async function handleMergeRequest(
 		const headSha = this.getNodeParameter('headSha', itemIndex, '') as string;
 		const startSha = this.getNodeParameter('startSha', itemIndex, '') as string;
 		const oldLine = this.getNodeParameter('oldLine', itemIndex, null) as number | null;
+		const lineRangeStartLineCode = this.getNodeParameter(
+			'lineRangeStartLineCode',
+			itemIndex,
+			'',
+		) as string;
+		const lineRangeStartType = this.getNodeParameter('lineRangeStartType', itemIndex, '') as string;
+		const lineRangeStartOldLine = this.getNodeParameter(
+			'lineRangeStartOldLine',
+			itemIndex,
+			null,
+		) as number | null;
+		const lineRangeStartNewLine = this.getNodeParameter(
+			'lineRangeStartNewLine',
+			itemIndex,
+			null,
+		) as number | null;
+		const lineRangeEndLineCode = this.getNodeParameter(
+			'lineRangeEndLineCode',
+			itemIndex,
+			'',
+		) as string;
+		const lineRangeEndType = this.getNodeParameter('lineRangeEndType', itemIndex, '') as string;
+		const lineRangeEndOldLine = this.getNodeParameter('lineRangeEndOldLine', itemIndex, null) as
+			| number
+			| null;
+		const lineRangeEndNewLine = this.getNodeParameter('lineRangeEndNewLine', itemIndex, null) as
+			| number
+			| null;
 
 		const hasPosition =
 			newPath !== '' && oldPath !== '' && baseSha !== '' && headSha !== '' && startSha !== '';
@@ -96,6 +124,36 @@ export async function handleMergeRequest(
 			}
 			if (oldLine !== null && oldLine !== 0) {
 				position.old_line = oldLine;
+			}
+			const hasLineRange =
+				lineRangeStartLineCode !== '' &&
+				lineRangeStartType !== '' &&
+				lineRangeEndLineCode !== '' &&
+				lineRangeEndType !== '';
+			if (hasLineRange) {
+				const lineRange: IDataObject = {
+					start: {
+						line_code: lineRangeStartLineCode,
+						type: lineRangeStartType,
+					} as IDataObject,
+					end: {
+						line_code: lineRangeEndLineCode,
+						type: lineRangeEndType,
+					} as IDataObject,
+				};
+				if (lineRangeStartOldLine !== null) {
+					(lineRange.start as IDataObject).old_line = lineRangeStartOldLine;
+				}
+				if (lineRangeStartNewLine !== null) {
+					(lineRange.start as IDataObject).new_line = lineRangeStartNewLine;
+				}
+				if (lineRangeEndOldLine !== null) {
+					(lineRange.end as IDataObject).old_line = lineRangeEndOldLine;
+				}
+				if (lineRangeEndNewLine !== null) {
+					(lineRange.end as IDataObject).new_line = lineRangeEndNewLine;
+				}
+				position.line_range = lineRange;
 			}
 			body.position = position;
 		}

--- a/tests/mergeRequestOperations.test.js
+++ b/tests/mergeRequestOperations.test.js
@@ -160,17 +160,56 @@ test('postDiscussionNote allows omitting line numbers', async () => {
 		startSha: '333',
 	});
 	await node.execute.call(ctx);
-	assert.deepStrictEqual(ctx.calls.options.body, {
-		body: 'nolines',
-		position: {
-			position_type: 'text',
-			new_path: 'a.ts',
-			old_path: 'a.ts',
-			base_sha: '111',
-			head_sha: '222',
-			start_sha: '333',
-		},
-	});
+        assert.deepStrictEqual(ctx.calls.options.body, {
+                body: 'nolines',
+                position: {
+                        position_type: 'text',
+                        new_path: 'a.ts',
+                        old_path: 'a.ts',
+                        base_sha: '111',
+                        head_sha: '222',
+                        start_sha: '333',
+                },
+        });
+});
+
+test('postDiscussionNote includes line range for multiline note', async () => {
+        const node = new GitlabExtended();
+        const ctx = createTrackedContext({
+                resource: 'mergeRequest',
+                operation: 'postDiscussionNote',
+                mergeRequestIid: 14,
+                body: 'multi',
+                startDiscussion: true,
+                positionType: 'text',
+                newPath: 'a.ts',
+                oldPath: 'a.ts',
+                baseSha: '111',
+                headSha: '222',
+                startSha: '333',
+                lineRangeStartLineCode: 'code1',
+                lineRangeStartType: 'new',
+                lineRangeEndLineCode: 'code2',
+                lineRangeEndType: 'old',
+                lineRangeStartOldLine: 5,
+                lineRangeEndNewLine: 7,
+        });
+        await node.execute.call(ctx);
+        assert.deepStrictEqual(ctx.calls.options.body, {
+                body: 'multi',
+                position: {
+                        position_type: 'text',
+                        new_path: 'a.ts',
+                        old_path: 'a.ts',
+                        base_sha: '111',
+                        head_sha: '222',
+                        start_sha: '333',
+                        line_range: {
+                                start: { line_code: 'code1', type: 'new', old_line: 5 },
+                                end: { line_code: 'code2', type: 'old', new_line: 7 },
+                        },
+                },
+        });
 });
 
 test('get builds correct endpoint', async () => {


### PR DESCRIPTION
## Summary
- support multi-line diff comments for merge requests
- document new line range parameters
- test multiline position handling

## Testing
- `npm run format:check`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840fdc82a88832b9b09e3a890948ad5