### PR TITLE
Fix optional parameter omissions

### DIFF
--- a/nodes/GitlabExtended/GitlabExtended.node.ts
+++ b/nodes/GitlabExtended/GitlabExtended.node.ts
@@ -1158,10 +1158,8 @@ export class GitlabExtended implements INodeType {
 						});
 					}
 					body.name = this.getNodeParameter('name', i);
-					body.description = this.getNodeParameter('releaseDescription', i);
-					if (body.description === undefined) {
-						body.description = '';
-					}
+					const releaseDescription = this.getNodeParameter('releaseDescription', i, '') as string;
+					if (releaseDescription) body.description = releaseDescription;
 					const assets = this.getNodeParameter('assets', i, '');
 					if (assets) {
 						try {
@@ -1177,10 +1175,8 @@ export class GitlabExtended implements INodeType {
 					requestMethod = 'PUT';
 					const tag = this.getNodeParameter('tagName', i) as string;
 					body.name = this.getNodeParameter('name', i);
-					body.description = this.getNodeParameter('releaseDescription', i);
-					if (body.description === undefined) {
-						body.description = '';
-					}
+					const releaseDescription = this.getNodeParameter('releaseDescription', i, '') as string;
+					if (releaseDescription) body.description = releaseDescription;
 					const assets = this.getNodeParameter('assets', i, '');
 					if (assets) {
 						try {
@@ -1253,7 +1249,8 @@ export class GitlabExtended implements INodeType {
 				if (operation === 'create') {
 					requestMethod = 'POST';
 					body.title = this.getNodeParameter('title', i);
-					body.description = this.getNodeParameter('description', i);
+					const issueDescription = this.getNodeParameter('description', i, '') as string;
+					if (issueDescription) body.description = issueDescription;
 					const labels = this.getNodeParameter('issueLabels', i, '');
 					if (labels) body.labels = labels;
 					endpoint = `${base}/issues`;
@@ -1272,10 +1269,13 @@ export class GitlabExtended implements INodeType {
 					const id = this.getNodeParameter('issueIid', i) as number;
 					requirePositive.call(this, id, 'issueIid', i);
 					body.title = this.getNodeParameter('title', i);
-					body.description = this.getNodeParameter('description', i);
+					const issueDescription = this.getNodeParameter('description', i, '') as string;
+					if (issueDescription) body.description = issueDescription;
 					const labels = this.getNodeParameter('issueLabels', i, '');
 					if (labels) body.labels = labels;
-					body.state_event = this.getNodeParameter('issueState', i);
+					if (Object.prototype.hasOwnProperty.call(this.getNode().parameters, 'issueState')) {
+						body.state_event = this.getNodeParameter('issueState', i);
+					}
 					endpoint = `${base}/issues/${id}`;
 				} else if (operation === 'close' || operation === 'reopen') {
 					requestMethod = 'PUT';

--- a/nodes/GitlabExtended/resources/branch.ts
+++ b/nodes/GitlabExtended/resources/branch.ts
@@ -68,8 +68,10 @@ export async function handleBranch(
 		const branch = this.getNodeParameter('branch', itemIndex) as string;
 		requireString.call(this, branch, 'branch', itemIndex);
 		body.name = branch;
-		body.developers_can_push = this.getNodeParameter('developersCanPush', itemIndex, false);
-		body.developers_can_merge = this.getNodeParameter('developersCanMerge', itemIndex, false);
+		const canPush = this.getNodeParameter('developersCanPush', itemIndex, false) as boolean;
+		if (canPush) body.developers_can_push = true;
+		const canMerge = this.getNodeParameter('developersCanMerge', itemIndex, false) as boolean;
+		if (canMerge) body.developers_can_merge = true;
 		endpoint = `${base}/protected_branches`;
 	} else if (operation === 'unprotect') {
 		requestMethod = 'DELETE';

--- a/nodes/GitlabExtended/resources/mergeRequest.ts
+++ b/nodes/GitlabExtended/resources/mergeRequest.ts
@@ -34,7 +34,8 @@ export async function handleMergeRequest(
 		body.source_branch = this.getNodeParameter('source', itemIndex);
 		body.target_branch = this.getNodeParameter('target', itemIndex);
 		body.title = this.getNodeParameter('title', itemIndex);
-		body.description = this.getNodeParameter('description', itemIndex);
+		const description = this.getNodeParameter('description', itemIndex, '') as string;
+		if (description) body.description = description;
 		endpoint = `${base}/merge_requests`;
 	} else if (operation === 'get') {
 		requestMethod = 'GET';
@@ -187,8 +188,9 @@ export async function handleMergeRequest(
 		requirePositive.call(this, noteId, 'noteId', itemIndex);
 		const newBody = this.getNodeParameter('body', itemIndex, '') as string;
 		if (newBody) body.body = newBody;
-		const resolved = this.getNodeParameter('resolved', itemIndex, false) as boolean;
-		body.resolved = resolved;
+		if (Object.prototype.hasOwnProperty.call(this.getNode().parameters, 'resolved')) {
+			body.resolved = this.getNodeParameter('resolved', itemIndex);
+		}
 		endpoint = `${base}/merge_requests/${iid}/discussions/${discussionId}/notes/${noteId}`;
 	} else if (operation === 'getChanges') {
 		requestMethod = 'GET';

--- a/tests/branchOperations.test.js
+++ b/tests/branchOperations.test.js
@@ -38,7 +38,6 @@ test('protect builds correct endpoint with flags', async () => {
   assert.deepStrictEqual(ctx.calls.options.body, {
     name: 'main',
     developers_can_push: true,
-    developers_can_merge: false,
   });
 });
 

--- a/tests/helpers/createContext.js
+++ b/tests/helpers/createContext.js
@@ -24,7 +24,7 @@ export default function createContext(params) {
       },
     },
     getNode() {
-      return {};
+      return { parameters: params };
     },
   };
 }

--- a/tests/issueOperations.test.js
+++ b/tests/issueOperations.test.js
@@ -28,6 +28,19 @@ test('update builds correct endpoint and body', async () => {
   });
 });
 
+test('update omits state_event when not set', async () => {
+  const node = new GitlabExtended();
+  const ctx = createContext({
+    resource: 'issue',
+    operation: 'update',
+    issueIid: 11,
+    title: 'x',
+    description: 'd',
+  });
+  await node.execute.call(ctx);
+  assert.deepStrictEqual(ctx.calls.options.body, { title: 'x', description: 'd' });
+});
+
 test('close builds correct endpoint', async () => {
   const node = new GitlabExtended();
   const ctx = createContext({ resource: 'issue', operation: 'close', issueIid: 3 });

--- a/tests/mergeRequestOperations.test.js
+++ b/tests/mergeRequestOperations.test.js
@@ -160,56 +160,56 @@ test('postDiscussionNote allows omitting line numbers', async () => {
 		startSha: '333',
 	});
 	await node.execute.call(ctx);
-        assert.deepStrictEqual(ctx.calls.options.body, {
-                body: 'nolines',
-                position: {
-                        position_type: 'text',
-                        new_path: 'a.ts',
-                        old_path: 'a.ts',
-                        base_sha: '111',
-                        head_sha: '222',
-                        start_sha: '333',
-                },
-        });
+	assert.deepStrictEqual(ctx.calls.options.body, {
+		body: 'nolines',
+		position: {
+			position_type: 'text',
+			new_path: 'a.ts',
+			old_path: 'a.ts',
+			base_sha: '111',
+			head_sha: '222',
+			start_sha: '333',
+		},
+	});
 });
 
 test('postDiscussionNote includes line range for multiline note', async () => {
-        const node = new GitlabExtended();
-        const ctx = createTrackedContext({
-                resource: 'mergeRequest',
-                operation: 'postDiscussionNote',
-                mergeRequestIid: 14,
-                body: 'multi',
-                startDiscussion: true,
-                positionType: 'text',
-                newPath: 'a.ts',
-                oldPath: 'a.ts',
-                baseSha: '111',
-                headSha: '222',
-                startSha: '333',
-                lineRangeStartLineCode: 'code1',
-                lineRangeStartType: 'new',
-                lineRangeEndLineCode: 'code2',
-                lineRangeEndType: 'old',
-                lineRangeStartOldLine: 5,
-                lineRangeEndNewLine: 7,
-        });
-        await node.execute.call(ctx);
-        assert.deepStrictEqual(ctx.calls.options.body, {
-                body: 'multi',
-                position: {
-                        position_type: 'text',
-                        new_path: 'a.ts',
-                        old_path: 'a.ts',
-                        base_sha: '111',
-                        head_sha: '222',
-                        start_sha: '333',
-                        line_range: {
-                                start: { line_code: 'code1', type: 'new', old_line: 5 },
-                                end: { line_code: 'code2', type: 'old', new_line: 7 },
-                        },
-                },
-        });
+	const node = new GitlabExtended();
+	const ctx = createTrackedContext({
+		resource: 'mergeRequest',
+		operation: 'postDiscussionNote',
+		mergeRequestIid: 14,
+		body: 'multi',
+		startDiscussion: true,
+		positionType: 'text',
+		newPath: 'a.ts',
+		oldPath: 'a.ts',
+		baseSha: '111',
+		headSha: '222',
+		startSha: '333',
+		lineRangeStartLineCode: 'code1',
+		lineRangeStartType: 'new',
+		lineRangeEndLineCode: 'code2',
+		lineRangeEndType: 'old',
+		lineRangeStartOldLine: 5,
+		lineRangeEndNewLine: 7,
+	});
+	await node.execute.call(ctx);
+	assert.deepStrictEqual(ctx.calls.options.body, {
+		body: 'multi',
+		position: {
+			position_type: 'text',
+			new_path: 'a.ts',
+			old_path: 'a.ts',
+			base_sha: '111',
+			head_sha: '222',
+			start_sha: '333',
+			line_range: {
+				start: { line_code: 'code1', type: 'new', old_line: 5 },
+				end: { line_code: 'code2', type: 'old', new_line: 7 },
+			},
+		},
+	});
 });
 
 test('get builds correct endpoint', async () => {
@@ -438,7 +438,7 @@ test('updateDiscussionNote builds correct endpoint and body', async () => {
 		ctx.calls.options.uri,
 		'https://gitlab.example.com/api/v4/projects/1/merge_requests/25/discussions/d5/notes/8',
 	);
-	assert.deepStrictEqual(ctx.calls.options.body, { body: 'fix', resolved: false });
+	assert.deepStrictEqual(ctx.calls.options.body, { body: 'fix' });
 });
 
 test('updateDiscussionNote can resolve note without body', async () => {

--- a/tests/releaseOperations.test.js
+++ b/tests/releaseOperations.test.js
@@ -73,7 +73,7 @@ test('create uses default values correctly', async () => {
   await node.execute.call(ctx);
   assert.strictEqual(ctx.calls.options.method, 'POST');
   assert.strictEqual(ctx.calls.options.uri, 'https://gitlab.example.com/api/v4/projects/1/releases');
-  assert.deepStrictEqual(ctx.calls.options.body, { tag_name: 'v1.0', name: '1.0', description: '' });
+  assert.deepStrictEqual(ctx.calls.options.body, { tag_name: 'v1.0', name: '1.0' });
 });
 
 test('create throws on invalid parameters', async () => {


### PR DESCRIPTION
## Summary
- only include issueState on update when provided
- skip resolved flag in updateDiscussionNote unless set
- expose node parameters in test helper
- test missing state_event handling

## Testing
- `npm run format:check`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68419f148128832b9169b64889e2a153