### PR TITLE
Add custom credential option

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,8 +42,8 @@ These roles are suggestions. Agents can be customized for other workflows such a
 ## Integration Steps (Summary)
 
 1. Install this package in n8n (through Community Nodes or `npm install` beforehand).
-2. Configure **Gitlab Extended API** credentials with your GitLab server URL and personal access token.
-3. Add an **AI Agent** node in n8n, choose an OpenAI Chat model, and attach the **GitLab Extended** tool with the credentials.
+2. Configure **Gitlab Extended API** credentials with your GitLab server URL and personal access token, or enable <strong>Use Custom Credentials</strong> in the node to provide them directly.
+3. Add an **AI Agent** node in n8n, choose an OpenAI Chat model, and attach the **GitLab Extended** tool with the credentials (if used).
 4. Provide a clear prompt describing the task. The agent will then plan tool actions and call GitLab accordingly.
 
 Keep prompts concise and prefer direct instructions like "fetch", "update", "create", or "delete". If multiple steps are required, describe the end goal and the agent will chain operations.

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ npm install n8n-nodes-extended-gitlab
 ## Usage
 
 1. Install the package through **Community Nodes** in the n8n settings or run `npm install n8n-nodes-extended-gitlab` in your n8n directory.
-2. Create **Gitlab Extended API** credentials providing your server URL, personal access token and default project ID.
-3. Drop the **Gitlab Extended** node into a workflow and select your credentials.
+2. Optionally create **Gitlab Extended API** credentials with your server URL, personal access token and default project ID.
+3. Drop the **Gitlab Extended** node into a workflow and either select your credentials or enable **Use Custom Credentials** to enter them directly in the node.
 4. Pick a resource and operation, then fill in the required fields.
 
 For example, choose `pipeline` and `getAll` to list all pipelines in your project.
@@ -199,7 +199,7 @@ sending the `resolved` flag when updating a note body with `updateDiscussionNote
 
 ## Credentials
 
-Authentication is handled exclusively via the <code>Gitlab Extended API</code> credentials. Create these credentials in n8n to store your GitLab server, access token and default project details in one place.
+Authentication can use the <code>Gitlab Extended API</code> credentials or the parameters entered directly in the node when <strong>Use Custom Credentials</strong> is enabled. Credentials allow you to store your GitLab server, access token and default project details in one place.
 
 The credentials' <code>server</code> field specifies your GitLab instance host (e.g. <code>https://gitlab.your-company.com</code>). Requests automatically use the <code>/api/v4</code> path.
 

--- a/nodes/GitlabExtended/GitlabExtended.node.ts
+++ b/nodes/GitlabExtended/GitlabExtended.node.ts
@@ -13,6 +13,7 @@ import {
 	gitlabApiRequestAllItems,
 	buildProjectBase,
 	assertValidProjectCredentials,
+	getCredentialData,
 	addOptionalStringParam,
 } from './GenericFunctions';
 import { requirePositive } from './validators';
@@ -38,10 +39,62 @@ export class GitlabExtended implements INodeType {
 		credentials: [
 			{
 				name: 'gitlabExtendedApi',
-				required: true,
+				required: false,
 			},
 		],
 		properties: [
+			{
+				displayName: 'Use Custom Credentials',
+				name: 'useCustomCredentials',
+				type: 'boolean',
+				default: false,
+				description: 'Whether to specify the GitLab server and token directly in this node',
+			},
+			{
+				displayName: 'Custom Credentials',
+				name: 'customCredentials',
+				type: 'collection',
+				displayOptions: { show: { useCustomCredentials: [true] } },
+				default: {},
+				options: [
+					{
+						displayName: 'Access Token',
+						name: 'accessToken',
+						type: 'string',
+						typeOptions: { password: true },
+						default: '',
+						description: 'Personal access token',
+					},
+					{
+						displayName: 'Gitlab Server',
+						name: 'server',
+						type: 'string',
+						default: 'https://gitlab.com',
+						description: 'Base URL of your GitLab instance',
+					},
+					{
+						displayName: 'Project ID',
+						name: 'projectId',
+						type: 'number',
+						default: 0,
+						description: 'Numeric project ID',
+					},
+					{
+						displayName: 'Project Name',
+						name: 'projectName',
+						type: 'string',
+						default: '',
+						description: 'Project slug or name',
+					},
+					{
+						displayName: 'Project Owner',
+						name: 'projectOwner',
+						type: 'string',
+						default: '',
+						description: 'Namespace or owner of the project',
+					},
+				],
+			},
 			{
 				displayName: 'Resource',
 				name: 'resource',
@@ -1112,7 +1165,7 @@ export class GitlabExtended implements INodeType {
 		const returnData: INodeExecutionData[] = [];
 		const operation = this.getNodeParameter('operation', 0);
 		const resource = this.getNodeParameter('resource', 0);
-		const credential = await this.getCredentials('gitlabExtendedApi');
+		const credential = await getCredentialData.call(this);
 		assertValidProjectCredentials.call(this, credential);
 
 		const base = buildProjectBase(credential);

--- a/nodes/GitlabExtended/resources/branch.ts
+++ b/nodes/GitlabExtended/resources/branch.ts
@@ -10,6 +10,7 @@ import {
 	gitlabApiRequestAllItems,
 	buildProjectBase,
 	assertValidProjectCredentials,
+	getCredentialData,
 } from '../GenericFunctions';
 import { requireString } from '../validators';
 
@@ -26,7 +27,7 @@ export async function handleBranch(
 	itemIndex: number,
 ): Promise<INodeExecutionData[]> {
 	const operation = this.getNodeParameter('operation', itemIndex);
-	const credential = await this.getCredentials('gitlabExtendedApi');
+	const credential = await getCredentialData.call(this);
 	assertValidProjectCredentials.call(this, credential);
 
 	const base = buildProjectBase(credential);

--- a/nodes/GitlabExtended/resources/file.ts
+++ b/nodes/GitlabExtended/resources/file.ts
@@ -10,6 +10,7 @@ import {
 	gitlabApiRequestAllItems,
 	buildProjectBase,
 	assertValidProjectCredentials,
+	getCredentialData,
 } from '../GenericFunctions';
 
 export async function handleFile(
@@ -17,7 +18,7 @@ export async function handleFile(
 	itemIndex: number,
 ): Promise<INodeExecutionData[]> {
 	const operation = this.getNodeParameter('operation', itemIndex);
-	const credential = await this.getCredentials('gitlabExtendedApi');
+	const credential = await getCredentialData.call(this);
 	assertValidProjectCredentials.call(this, credential);
 
 	const base = buildProjectBase(credential);

--- a/nodes/GitlabExtended/resources/mergeRequest.ts
+++ b/nodes/GitlabExtended/resources/mergeRequest.ts
@@ -10,6 +10,7 @@ import {
 	gitlabApiRequestAllItems,
 	buildProjectBase,
 	assertValidProjectCredentials,
+	getCredentialData,
 	addOptionalStringParam,
 } from '../GenericFunctions';
 import { requirePositive } from '../validators';
@@ -19,7 +20,7 @@ export async function handleMergeRequest(
 	itemIndex: number,
 ): Promise<INodeExecutionData[]> {
 	const operation = this.getNodeParameter('operation', itemIndex);
-	const credential = await this.getCredentials('gitlabExtendedApi');
+	const credential = await getCredentialData.call(this);
 	assertValidProjectCredentials.call(this, credential);
 
 	const base = buildProjectBase(credential);

--- a/nodes/GitlabExtended/resources/pipeline.ts
+++ b/nodes/GitlabExtended/resources/pipeline.ts
@@ -10,6 +10,7 @@ import {
 	gitlabApiRequestAllItems,
 	buildProjectBase,
 	assertValidProjectCredentials,
+	getCredentialData,
 } from '../GenericFunctions';
 import { requirePositive } from '../validators';
 
@@ -18,7 +19,7 @@ export async function handlePipeline(
 	itemIndex: number,
 ): Promise<INodeExecutionData[]> {
 	const operation = this.getNodeParameter('operation', itemIndex);
-	const credential = await this.getCredentials('gitlabExtendedApi');
+	const credential = await getCredentialData.call(this);
 	assertValidProjectCredentials.call(this, credential);
 
 	const base = buildProjectBase(credential);

--- a/tests/helpers/createContext.js
+++ b/tests/helpers/createContext.js
@@ -1,18 +1,27 @@
 export default function createContext(params) {
   const calls = {};
+  const { useCustomCredentials = false, customCredentials = {} } = params;
   return {
     calls,
     getInputData() {
       return [{ json: {} }];
     },
     getNodeParameter(name) {
+      if (name === 'useCustomCredentials') return useCustomCredentials;
+      if (name === 'customCredentials') return customCredentials;
       return params[name];
     },
     async getCredentials() {
+      calls.credentials = 'gitlabExtendedApi';
+      if (useCustomCredentials) return {};
       return { server: 'https://gitlab.example.com', accessToken: 't', projectId: 1 };
     },
     helpers: {
       async requestWithAuthentication(name, options) {
+        calls.options = options;
+        return {};
+      },
+      async httpRequest(options) {
         calls.options = options;
         return {};
       },


### PR DESCRIPTION
## Summary
- allow providing GitLab token and server directly in node
- make credentials optional when custom data is supplied
- document how to use custom credentials
- update tests

## Testing
- `npm run format:check`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6879071e51b0832ba21640248f75d26a