### PR TITLE
Add inline credential option

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ npm install n8n-nodes-extended-gitlab
 ## Usage
 
 1. Install the package through **Community Nodes** in the n8n settings or run `npm install n8n-nodes-extended-gitlab` in your n8n directory.
-2. Create **Gitlab Extended API** credentials providing your server URL, personal access token and default project ID.
-3. Drop the **Gitlab Extended** node into a workflow and select your credentials.
+2. (Optional) Create **Gitlab Extended API** credentials providing your server URL, personal access token and default project ID.
+3. Drop the **Gitlab Extended** node into a workflow and either select credentials or enable <em>Use Custom Credentials</em> to provide the details directly in the node.
 4. Pick a resource and operation, then fill in the required fields.
 
 For example, choose `pipeline` and `getAll` to list all pipelines in your project.
@@ -199,7 +199,7 @@ sending the `resolved` flag when updating a note body with `updateDiscussionNote
 
 ## Credentials
 
-Authentication is handled exclusively via the <code>Gitlab Extended API</code> credentials. Create these credentials in n8n to store your GitLab server, access token and default project details in one place.
+Authentication can use the <code>Gitlab Extended API</code> credentials or manual parameters. Credentials let you store your GitLab server, access token and default project details in one place, while the <em>Use Custom Credentials</em> option lets you supply them per node.
 
 The credentials' <code>server</code> field specifies your GitLab instance host (e.g. <code>https://gitlab.your-company.com</code>). Requests automatically use the <code>/api/v4</code> path.
 

--- a/nodes/GitlabExtended/resources/branch.ts
+++ b/nodes/GitlabExtended/resources/branch.ts
@@ -10,6 +10,7 @@ import {
 	gitlabApiRequestAllItems,
 	buildProjectBase,
 	assertValidProjectCredentials,
+	resolveCredentials,
 } from '../GenericFunctions';
 import { requireString } from '../validators';
 
@@ -26,7 +27,7 @@ export async function handleBranch(
 	itemIndex: number,
 ): Promise<INodeExecutionData[]> {
 	const operation = this.getNodeParameter('operation', itemIndex);
-	const credential = await this.getCredentials('gitlabExtendedApi');
+	const credential = await resolveCredentials.call(this, itemIndex);
 	assertValidProjectCredentials.call(this, credential);
 
 	const base = buildProjectBase(credential);
@@ -94,8 +95,8 @@ export async function handleBranch(
 	}
 
 	const response = returnAll
-		? await gitlabApiRequestAllItems.call(this, requestMethod, endpoint, body, qs)
-		: await gitlabApiRequest.call(this, requestMethod, endpoint, body, qs);
+		? await gitlabApiRequestAllItems.call(this, requestMethod, endpoint, body, qs, itemIndex)
+		: await gitlabApiRequest.call(this, requestMethod, endpoint, body, qs, {}, itemIndex);
 
 	return this.helpers.constructExecutionMetaData(
 		this.helpers.returnJsonArray(response as IDataObject),

--- a/nodes/GitlabExtended/resources/file.ts
+++ b/nodes/GitlabExtended/resources/file.ts
@@ -10,6 +10,7 @@ import {
 	gitlabApiRequestAllItems,
 	buildProjectBase,
 	assertValidProjectCredentials,
+	resolveCredentials,
 } from '../GenericFunctions';
 
 export async function handleFile(
@@ -17,7 +18,7 @@ export async function handleFile(
 	itemIndex: number,
 ): Promise<INodeExecutionData[]> {
 	const operation = this.getNodeParameter('operation', itemIndex);
-	const credential = await this.getCredentials('gitlabExtendedApi');
+	const credential = await resolveCredentials.call(this, itemIndex);
 	assertValidProjectCredentials.call(this, credential);
 
 	const base = buildProjectBase(credential);
@@ -61,8 +62,8 @@ export async function handleFile(
 	}
 
 	const response = returnAll
-		? await gitlabApiRequestAllItems.call(this, requestMethod, endpoint, body, qs)
-		: await gitlabApiRequest.call(this, requestMethod, endpoint, body, qs);
+		? await gitlabApiRequestAllItems.call(this, requestMethod, endpoint, body, qs, itemIndex)
+		: await gitlabApiRequest.call(this, requestMethod, endpoint, body, qs, {}, itemIndex);
 
 	return this.helpers.constructExecutionMetaData(
 		this.helpers.returnJsonArray(response as IDataObject),

--- a/nodes/GitlabExtended/resources/mergeRequest.ts
+++ b/nodes/GitlabExtended/resources/mergeRequest.ts
@@ -10,6 +10,7 @@ import {
 	gitlabApiRequestAllItems,
 	buildProjectBase,
 	assertValidProjectCredentials,
+	resolveCredentials,
 	addOptionalStringParam,
 } from '../GenericFunctions';
 import { requirePositive } from '../validators';
@@ -19,7 +20,7 @@ export async function handleMergeRequest(
 	itemIndex: number,
 ): Promise<INodeExecutionData[]> {
 	const operation = this.getNodeParameter('operation', itemIndex);
-	const credential = await this.getCredentials('gitlabExtendedApi');
+	const credential = await resolveCredentials.call(this, itemIndex);
 	assertValidProjectCredentials.call(this, credential);
 
 	const base = buildProjectBase(credential);
@@ -306,8 +307,8 @@ export async function handleMergeRequest(
 	}
 
 	const response = returnAll
-		? await gitlabApiRequestAllItems.call(this, requestMethod, endpoint, body, qs)
-		: await gitlabApiRequest.call(this, requestMethod, endpoint, body, qs);
+		? await gitlabApiRequestAllItems.call(this, requestMethod, endpoint, body, qs, itemIndex)
+		: await gitlabApiRequest.call(this, requestMethod, endpoint, body, qs, {}, itemIndex);
 
 	return this.helpers.constructExecutionMetaData(
 		this.helpers.returnJsonArray(response as IDataObject),

--- a/nodes/GitlabExtended/resources/pipeline.ts
+++ b/nodes/GitlabExtended/resources/pipeline.ts
@@ -10,6 +10,7 @@ import {
 	gitlabApiRequestAllItems,
 	buildProjectBase,
 	assertValidProjectCredentials,
+	resolveCredentials,
 } from '../GenericFunctions';
 import { requirePositive } from '../validators';
 
@@ -18,7 +19,7 @@ export async function handlePipeline(
 	itemIndex: number,
 ): Promise<INodeExecutionData[]> {
 	const operation = this.getNodeParameter('operation', itemIndex);
-	const credential = await this.getCredentials('gitlabExtendedApi');
+	const credential = await resolveCredentials.call(this, itemIndex);
 	assertValidProjectCredentials.call(this, credential);
 
 	const base = buildProjectBase(credential);
@@ -73,8 +74,8 @@ export async function handlePipeline(
 	}
 
 	const response = returnAll
-		? await gitlabApiRequestAllItems.call(this, requestMethod, endpoint, body, qs)
-		: await gitlabApiRequest.call(this, requestMethod, endpoint, body, qs);
+		? await gitlabApiRequestAllItems.call(this, requestMethod, endpoint, body, qs, itemIndex)
+		: await gitlabApiRequest.call(this, requestMethod, endpoint, body, qs, {}, itemIndex);
 
 	return this.helpers.constructExecutionMetaData(
 		this.helpers.returnJsonArray(response as IDataObject),

--- a/tests/helpers/createContext.js
+++ b/tests/helpers/createContext.js
@@ -5,14 +5,18 @@ export default function createContext(params) {
     getInputData() {
       return [{ json: {} }];
     },
-    getNodeParameter(name) {
-      return params[name];
+    getNodeParameter(name, _index, defaultValue) {
+      return params[name] !== undefined ? params[name] : defaultValue;
     },
     async getCredentials() {
       return { server: 'https://gitlab.example.com', accessToken: 't', projectId: 1 };
     },
     helpers: {
       async requestWithAuthentication(name, options) {
+        calls.options = options;
+        return {};
+      },
+      async httpRequest(options) {
         calls.options = options;
         return {};
       },


### PR DESCRIPTION
## Summary
- add optional `useCustom` credential fields
- handle inline credentials in GenericFunctions
- update tests for new authentication option
- document the feature in README

## Testing
- `npm run format:check`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6879071e51b0832ba21640248f75d26a