### PR TITLE
Add optional custom credentials

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ These roles are suggestions. Agents can be customized for other workflows such a
 ## Integration Steps (Summary)
 
 1. Install this package in n8n (through Community Nodes or `npm install` beforehand).
-2. Configure **Gitlab Extended API** credentials with your GitLab server URL and personal access token.
+2. Configure **Gitlab Extended API** credentials with your GitLab server URL and personal access token, or choose "Custom" authentication in the node to enter these details per workflow.
 3. Add an **AI Agent** node in n8n, choose an OpenAI Chat model, and attach the **GitLab Extended** tool with the credentials.
 4. Provide a clear prompt describing the task. The agent will then plan tool actions and call GitLab accordingly.
 

--- a/README.md
+++ b/README.md
@@ -199,9 +199,9 @@ sending the `resolved` flag when updating a note body with `updateDiscussionNote
 
 ## Credentials
 
-Authentication is handled exclusively via the <code>Gitlab Extended API</code> credentials. Create these credentials in n8n to store your GitLab server, access token and default project details in one place.
+Authentication can use the saved <code>Gitlab Extended API</code> credentials or custom values entered directly in the node. When selecting <strong>Custom</strong> authentication you provide the server URL, token and project details on the node itself.
 
-The credentials' <code>server</code> field specifies your GitLab instance host (e.g. <code>https://gitlab.your-company.com</code>). Requests automatically use the <code>/api/v4</code> path.
+The credentials' or custom <code>server</code> field specifies your GitLab instance host (e.g. <code>https://gitlab.your-company.com</code>). Requests automatically use the <code>/api/v4</code> path.
 
 ## Compatibility
 

--- a/nodes/GitlabExtended/GitlabExtended.node.ts
+++ b/nodes/GitlabExtended/GitlabExtended.node.ts
@@ -14,6 +14,7 @@ import {
 	buildProjectBase,
 	assertValidProjectCredentials,
 	addOptionalStringParam,
+	resolveCredential,
 } from './GenericFunctions';
 import { requirePositive } from './validators';
 import { handleBranch } from './resources/branch';
@@ -38,10 +39,62 @@ export class GitlabExtended implements INodeType {
 		credentials: [
 			{
 				name: 'gitlabExtendedApi',
-				required: true,
+				required: false,
 			},
 		],
 		properties: [
+			{
+				displayName: 'Authentication',
+				name: 'authentication',
+				type: 'options',
+				options: [
+					{ name: 'Credential', value: 'credential' },
+					{ name: 'Custom', value: 'custom' },
+				],
+				default: 'credential',
+				description: 'Select whether to use saved credentials or custom fields for this node',
+			},
+			{
+				displayName: 'GitLab Server',
+				name: 'server',
+				type: 'string',
+				default: 'https://gitlab.com',
+				displayOptions: { show: { authentication: ['custom'] } },
+				description: 'Base URL of your GitLab instance, for example "https://gitlab.com"',
+			},
+			{
+				displayName: 'Access Token',
+				name: 'accessToken',
+				type: 'string',
+				typeOptions: { password: true },
+				default: '',
+				displayOptions: { show: { authentication: ['custom'] } },
+				description: 'Personal access token with API permissions',
+			},
+			{
+				displayName: 'Project Owner',
+				name: 'projectOwner',
+				type: 'string',
+				default: '',
+				displayOptions: { show: { authentication: ['custom'] } },
+				description: 'Namespace or owner of the project. Ignored if "Project ID" is set.',
+			},
+			{
+				displayName: 'Project Name',
+				name: 'projectName',
+				type: 'string',
+				default: '',
+				displayOptions: { show: { authentication: ['custom'] } },
+				description: 'Project slug or name. Ignored if "Project ID" is set.',
+			},
+			{
+				displayName: 'Project ID',
+				name: 'projectId',
+				type: 'number',
+				default: 0,
+				displayOptions: { show: { authentication: ['custom'] } },
+				description: 'Numeric project ID. Takes precedence over owner and name if provided.',
+			},
 			{
 				displayName: 'Resource',
 				name: 'resource',
@@ -1112,12 +1165,14 @@ export class GitlabExtended implements INodeType {
 		const returnData: INodeExecutionData[] = [];
 		const operation = this.getNodeParameter('operation', 0);
 		const resource = this.getNodeParameter('resource', 0);
-		const credential = await this.getCredentials('gitlabExtendedApi');
-		assertValidProjectCredentials.call(this, credential);
-
-		const base = buildProjectBase(credential);
+		const authCheck = await resolveCredential.call(this, 0);
+		assertValidProjectCredentials.call(this, authCheck);
 
 		for (let i = 0; i < items.length; i++) {
+			const credential = await resolveCredential.call(this, i);
+			assertValidProjectCredentials.call(this, credential);
+			const base = buildProjectBase(credential);
+
 			let requestMethod: IHttpRequestMethods = 'GET';
 			let endpoint = '';
 			let body: IDataObject = {};
@@ -1304,8 +1359,8 @@ export class GitlabExtended implements INodeType {
 			}
 
 			const response = returnAll
-				? await gitlabApiRequestAllItems.call(this, requestMethod, endpoint, body, qs)
-				: await gitlabApiRequest.call(this, requestMethod, endpoint, body, qs);
+				? await gitlabApiRequestAllItems.call(this, requestMethod, endpoint, body, qs, i)
+				: await gitlabApiRequest.call(this, requestMethod, endpoint, body, qs, {}, i);
 
 			const executionData = this.helpers.constructExecutionMetaData(
 				this.helpers.returnJsonArray(response as IDataObject),

--- a/nodes/GitlabExtended/resources/branch.ts
+++ b/nodes/GitlabExtended/resources/branch.ts
@@ -10,6 +10,7 @@ import {
 	gitlabApiRequestAllItems,
 	buildProjectBase,
 	assertValidProjectCredentials,
+	resolveCredential,
 } from '../GenericFunctions';
 import { requireString } from '../validators';
 
@@ -26,7 +27,7 @@ export async function handleBranch(
 	itemIndex: number,
 ): Promise<INodeExecutionData[]> {
 	const operation = this.getNodeParameter('operation', itemIndex);
-	const credential = await this.getCredentials('gitlabExtendedApi');
+	const credential = await resolveCredential.call(this, itemIndex);
 	assertValidProjectCredentials.call(this, credential);
 
 	const base = buildProjectBase(credential);
@@ -94,8 +95,8 @@ export async function handleBranch(
 	}
 
 	const response = returnAll
-		? await gitlabApiRequestAllItems.call(this, requestMethod, endpoint, body, qs)
-		: await gitlabApiRequest.call(this, requestMethod, endpoint, body, qs);
+		? await gitlabApiRequestAllItems.call(this, requestMethod, endpoint, body, qs, itemIndex)
+		: await gitlabApiRequest.call(this, requestMethod, endpoint, body, qs, {}, itemIndex);
 
 	return this.helpers.constructExecutionMetaData(
 		this.helpers.returnJsonArray(response as IDataObject),

--- a/nodes/GitlabExtended/resources/file.ts
+++ b/nodes/GitlabExtended/resources/file.ts
@@ -10,6 +10,7 @@ import {
 	gitlabApiRequestAllItems,
 	buildProjectBase,
 	assertValidProjectCredentials,
+	resolveCredential,
 } from '../GenericFunctions';
 
 export async function handleFile(
@@ -17,7 +18,7 @@ export async function handleFile(
 	itemIndex: number,
 ): Promise<INodeExecutionData[]> {
 	const operation = this.getNodeParameter('operation', itemIndex);
-	const credential = await this.getCredentials('gitlabExtendedApi');
+	const credential = await resolveCredential.call(this, itemIndex);
 	assertValidProjectCredentials.call(this, credential);
 
 	const base = buildProjectBase(credential);
@@ -61,8 +62,8 @@ export async function handleFile(
 	}
 
 	const response = returnAll
-		? await gitlabApiRequestAllItems.call(this, requestMethod, endpoint, body, qs)
-		: await gitlabApiRequest.call(this, requestMethod, endpoint, body, qs);
+		? await gitlabApiRequestAllItems.call(this, requestMethod, endpoint, body, qs, itemIndex)
+		: await gitlabApiRequest.call(this, requestMethod, endpoint, body, qs, {}, itemIndex);
 
 	return this.helpers.constructExecutionMetaData(
 		this.helpers.returnJsonArray(response as IDataObject),

--- a/nodes/GitlabExtended/resources/mergeRequest.ts
+++ b/nodes/GitlabExtended/resources/mergeRequest.ts
@@ -11,6 +11,7 @@ import {
 	buildProjectBase,
 	assertValidProjectCredentials,
 	addOptionalStringParam,
+	resolveCredential,
 } from '../GenericFunctions';
 import { requirePositive } from '../validators';
 
@@ -19,7 +20,7 @@ export async function handleMergeRequest(
 	itemIndex: number,
 ): Promise<INodeExecutionData[]> {
 	const operation = this.getNodeParameter('operation', itemIndex);
-	const credential = await this.getCredentials('gitlabExtendedApi');
+	const credential = await resolveCredential.call(this, itemIndex);
 	assertValidProjectCredentials.call(this, credential);
 
 	const base = buildProjectBase(credential);
@@ -306,8 +307,8 @@ export async function handleMergeRequest(
 	}
 
 	const response = returnAll
-		? await gitlabApiRequestAllItems.call(this, requestMethod, endpoint, body, qs)
-		: await gitlabApiRequest.call(this, requestMethod, endpoint, body, qs);
+		? await gitlabApiRequestAllItems.call(this, requestMethod, endpoint, body, qs, itemIndex)
+		: await gitlabApiRequest.call(this, requestMethod, endpoint, body, qs, {}, itemIndex);
 
 	return this.helpers.constructExecutionMetaData(
 		this.helpers.returnJsonArray(response as IDataObject),

--- a/nodes/GitlabExtended/resources/pipeline.ts
+++ b/nodes/GitlabExtended/resources/pipeline.ts
@@ -10,6 +10,7 @@ import {
 	gitlabApiRequestAllItems,
 	buildProjectBase,
 	assertValidProjectCredentials,
+	resolveCredential,
 } from '../GenericFunctions';
 import { requirePositive } from '../validators';
 
@@ -18,7 +19,7 @@ export async function handlePipeline(
 	itemIndex: number,
 ): Promise<INodeExecutionData[]> {
 	const operation = this.getNodeParameter('operation', itemIndex);
-	const credential = await this.getCredentials('gitlabExtendedApi');
+	const credential = await resolveCredential.call(this, itemIndex);
 	assertValidProjectCredentials.call(this, credential);
 
 	const base = buildProjectBase(credential);
@@ -73,8 +74,8 @@ export async function handlePipeline(
 	}
 
 	const response = returnAll
-		? await gitlabApiRequestAllItems.call(this, requestMethod, endpoint, body, qs)
-		: await gitlabApiRequest.call(this, requestMethod, endpoint, body, qs);
+		? await gitlabApiRequestAllItems.call(this, requestMethod, endpoint, body, qs, itemIndex)
+		: await gitlabApiRequest.call(this, requestMethod, endpoint, body, qs, {}, itemIndex);
 
 	return this.helpers.constructExecutionMetaData(
 		this.helpers.returnJsonArray(response as IDataObject),

--- a/tests/helpers/createContext.js
+++ b/tests/helpers/createContext.js
@@ -5,8 +5,10 @@ export default function createContext(params) {
     getInputData() {
       return [{ json: {} }];
     },
-    getNodeParameter(name) {
-      return params[name];
+    getNodeParameter(name, _index, fallback) {
+      return Object.prototype.hasOwnProperty.call(params, name)
+        ? params[name]
+        : fallback;
     },
     async getCredentials() {
       return { server: 'https://gitlab.example.com', accessToken: 't', projectId: 1 };


### PR DESCRIPTION
## Summary
- support custom credentials via new `authentication` option
- update helper functions to use `resolveCredential`
- make Gitlab credentials optional in node
- document custom auth in README and agent guide
- add tests for custom auth

## Testing
- `npm run format:check`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6879071e51b0832ba21640248f75d26a