### PR TITLE
Fix custom auth requests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ These roles are suggestions. Agents can be customized for other workflows such a
 ## Integration Steps (Summary)
 
 1. Install this package in n8n (through Community Nodes or `npm install` beforehand).
-2. Configure **Gitlab Extended API** credentials with your GitLab server URL and personal access token.
+2. Configure **Gitlab Extended API** credentials with your GitLab server URL and personal access token, or choose "Custom" authentication in the node to enter these details per workflow.
 3. Add an **AI Agent** node in n8n, choose an OpenAI Chat model, and attach the **GitLab Extended** tool with the credentials.
 4. Provide a clear prompt describing the task. The agent will then plan tool actions and call GitLab accordingly.
 

--- a/README.md
+++ b/README.md
@@ -199,9 +199,9 @@ sending the `resolved` flag when updating a note body with `updateDiscussionNote
 
 ## Credentials
 
-Authentication is handled exclusively via the <code>Gitlab Extended API</code> credentials. Create these credentials in n8n to store your GitLab server, access token and default project details in one place.
+Authentication can use the saved <code>Gitlab Extended API</code> credentials or custom values entered directly in the node. When selecting <strong>Custom</strong> authentication you provide the server URL, token and project details on the node itself.
 
-The credentials' <code>server</code> field specifies your GitLab instance host (e.g. <code>https://gitlab.your-company.com</code>). Requests automatically use the <code>/api/v4</code> path.
+The credentials' or custom <code>server</code> field specifies your GitLab instance host (e.g. <code>https://gitlab.your-company.com</code>). Requests automatically use the <code>/api/v4</code> path.
 
 ## Compatibility
 

--- a/nodes/GitlabExtended/GenericFunctions.ts
+++ b/nodes/GitlabExtended/GenericFunctions.ts
@@ -8,6 +8,23 @@ import type {
 } from 'n8n-workflow';
 import { NodeApiError, NodeOperationError } from 'n8n-workflow';
 
+export async function resolveCredential(
+	this: IHookFunctions | IExecuteFunctions,
+	itemIndex = 0,
+): Promise<IDataObject> {
+	const mode = this.getNodeParameter('authentication', itemIndex, 'credential') as string;
+	if (mode === 'custom') {
+		return {
+			server: this.getNodeParameter('server', itemIndex) as string,
+			accessToken: this.getNodeParameter('accessToken', itemIndex) as string,
+			projectOwner: this.getNodeParameter('projectOwner', itemIndex, '') as string,
+			projectName: this.getNodeParameter('projectName', itemIndex, '') as string,
+			projectId: this.getNodeParameter('projectId', itemIndex, 0) as number,
+		};
+	}
+	return this.getCredentials('gitlabExtendedApi');
+}
+
 /**
  * Make an API request to Gitlab
  *
@@ -26,6 +43,7 @@ export async function gitlabApiRequest(
 	body: object,
 	query?: IDataObject,
 	option: IDataObject = {},
+	itemIndex = 0,
 ): Promise<any> {
 	const options: IRequestOptions = {
 		method,
@@ -43,7 +61,8 @@ export async function gitlabApiRequest(
 		delete options.qs;
 	}
 
-	const credential = await this.getCredentials('gitlabExtendedApi');
+	const mode = this.getNodeParameter('authentication', itemIndex, 'credential') as string;
+	const credential = await resolveCredential.call(this, itemIndex);
 	const server = credential.server as string | undefined;
 	if (!server) {
 		throw new NodeOperationError(this.getNode(), 'GitLab server URL is missing in credentials');
@@ -56,6 +75,10 @@ export async function gitlabApiRequest(
 
 	try {
 		options.uri = `${baseUrl}${endpoint}`;
+		if (mode === 'custom') {
+			(options.headers as IDataObject)['Private-Token'] = credential.accessToken as string;
+			return await this.helpers.request.call(this, options);
+		}
 		return await this.helpers.requestWithAuthentication.call(this, 'gitlabExtendedApi', options);
 	} catch (error) {
 		let description;
@@ -87,6 +110,7 @@ export async function gitlabApiRequestAllItems(
 	endpoint: string,
 	body: any = {},
 	query: IDataObject = {},
+	itemIndex = 0,
 ): Promise<any> {
 	const returnData: IDataObject[] = [];
 
@@ -96,9 +120,17 @@ export async function gitlabApiRequestAllItems(
 	query.page = 1;
 
 	do {
-		responseData = await gitlabApiRequest.call(this, method, endpoint, body as IDataObject, query, {
-			resolveWithFullResponse: true,
-		});
+		responseData = await gitlabApiRequest.call(
+			this,
+			method,
+			endpoint,
+			body as IDataObject,
+			query,
+			{
+				resolveWithFullResponse: true,
+			},
+			itemIndex,
+		);
 		query.page++;
 		returnData.push.apply(returnData, responseData.body as IDataObject[]);
 	} while (responseData.headers['x-next-page']);
@@ -152,14 +184,15 @@ export async function getMergeRequestDiscussion(
 	mergeRequestIid: number,
 	discussionId: string,
 	query: IDataObject = {},
+	itemIndex = 0,
 ): Promise<any> {
 	if (mergeRequestIid <= 0) {
 		throw new NodeOperationError(this.getNode(), 'mergeRequestIid must be a positive number');
 	}
-	const credential = await this.getCredentials('gitlabExtendedApi');
+	const credential = await resolveCredential.call(this, itemIndex);
 	const base = buildProjectBase(credential);
 	const endpoint = `${base}/merge_requests/${mergeRequestIid}/discussions/${encodeURIComponent(discussionId)}`;
-	return gitlabApiRequest.call(this, 'GET', endpoint, {}, query);
+	return gitlabApiRequest.call(this, 'GET', endpoint, {}, query, {}, itemIndex);
 }
 
 /**

--- a/nodes/GitlabExtended/GitlabExtended.node.ts
+++ b/nodes/GitlabExtended/GitlabExtended.node.ts
@@ -14,6 +14,7 @@ import {
 	buildProjectBase,
 	assertValidProjectCredentials,
 	addOptionalStringParam,
+	resolveCredential,
 } from './GenericFunctions';
 import { requirePositive } from './validators';
 import { handleBranch } from './resources/branch';
@@ -38,10 +39,62 @@ export class GitlabExtended implements INodeType {
 		credentials: [
 			{
 				name: 'gitlabExtendedApi',
-				required: true,
+				required: false,
 			},
 		],
 		properties: [
+			{
+				displayName: 'Authentication',
+				name: 'authentication',
+				type: 'options',
+				options: [
+					{ name: 'Credential', value: 'credential' },
+					{ name: 'Custom', value: 'custom' },
+				],
+				default: 'credential',
+				description: 'Select whether to use saved credentials or custom fields for this node',
+			},
+			{
+				displayName: 'GitLab Server',
+				name: 'server',
+				type: 'string',
+				default: 'https://gitlab.com',
+				displayOptions: { show: { authentication: ['custom'] } },
+				description: 'Base URL of your GitLab instance, for example "https://gitlab.com"',
+			},
+			{
+				displayName: 'Access Token',
+				name: 'accessToken',
+				type: 'string',
+				typeOptions: { password: true },
+				default: '',
+				displayOptions: { show: { authentication: ['custom'] } },
+				description: 'Personal access token with API permissions',
+			},
+			{
+				displayName: 'Project Owner',
+				name: 'projectOwner',
+				type: 'string',
+				default: '',
+				displayOptions: { show: { authentication: ['custom'] } },
+				description: 'Namespace or owner of the project. Ignored if "Project ID" is set.',
+			},
+			{
+				displayName: 'Project Name',
+				name: 'projectName',
+				type: 'string',
+				default: '',
+				displayOptions: { show: { authentication: ['custom'] } },
+				description: 'Project slug or name. Ignored if "Project ID" is set.',
+			},
+			{
+				displayName: 'Project ID',
+				name: 'projectId',
+				type: 'number',
+				default: 0,
+				displayOptions: { show: { authentication: ['custom'] } },
+				description: 'Numeric project ID. Takes precedence over owner and name if provided.',
+			},
 			{
 				displayName: 'Resource',
 				name: 'resource',
@@ -1112,12 +1165,14 @@ export class GitlabExtended implements INodeType {
 		const returnData: INodeExecutionData[] = [];
 		const operation = this.getNodeParameter('operation', 0);
 		const resource = this.getNodeParameter('resource', 0);
-		const credential = await this.getCredentials('gitlabExtendedApi');
-		assertValidProjectCredentials.call(this, credential);
-
-		const base = buildProjectBase(credential);
+		const authCheck = await resolveCredential.call(this, 0);
+		assertValidProjectCredentials.call(this, authCheck);
 
 		for (let i = 0; i < items.length; i++) {
+			const credential = await resolveCredential.call(this, i);
+			assertValidProjectCredentials.call(this, credential);
+			const base = buildProjectBase(credential);
+
 			let requestMethod: IHttpRequestMethods = 'GET';
 			let endpoint = '';
 			let body: IDataObject = {};
@@ -1304,8 +1359,8 @@ export class GitlabExtended implements INodeType {
 			}
 
 			const response = returnAll
-				? await gitlabApiRequestAllItems.call(this, requestMethod, endpoint, body, qs)
-				: await gitlabApiRequest.call(this, requestMethod, endpoint, body, qs);
+				? await gitlabApiRequestAllItems.call(this, requestMethod, endpoint, body, qs, i)
+				: await gitlabApiRequest.call(this, requestMethod, endpoint, body, qs, {}, i);
 
 			const executionData = this.helpers.constructExecutionMetaData(
 				this.helpers.returnJsonArray(response as IDataObject),

--- a/nodes/GitlabExtended/resources/branch.ts
+++ b/nodes/GitlabExtended/resources/branch.ts
@@ -10,6 +10,7 @@ import {
 	gitlabApiRequestAllItems,
 	buildProjectBase,
 	assertValidProjectCredentials,
+	resolveCredential,
 } from '../GenericFunctions';
 import { requireString } from '../validators';
 
@@ -26,7 +27,7 @@ export async function handleBranch(
 	itemIndex: number,
 ): Promise<INodeExecutionData[]> {
 	const operation = this.getNodeParameter('operation', itemIndex);
-	const credential = await this.getCredentials('gitlabExtendedApi');
+	const credential = await resolveCredential.call(this, itemIndex);
 	assertValidProjectCredentials.call(this, credential);
 
 	const base = buildProjectBase(credential);
@@ -94,8 +95,8 @@ export async function handleBranch(
 	}
 
 	const response = returnAll
-		? await gitlabApiRequestAllItems.call(this, requestMethod, endpoint, body, qs)
-		: await gitlabApiRequest.call(this, requestMethod, endpoint, body, qs);
+		? await gitlabApiRequestAllItems.call(this, requestMethod, endpoint, body, qs, itemIndex)
+		: await gitlabApiRequest.call(this, requestMethod, endpoint, body, qs, {}, itemIndex);
 
 	return this.helpers.constructExecutionMetaData(
 		this.helpers.returnJsonArray(response as IDataObject),

--- a/nodes/GitlabExtended/resources/file.ts
+++ b/nodes/GitlabExtended/resources/file.ts
@@ -10,6 +10,7 @@ import {
 	gitlabApiRequestAllItems,
 	buildProjectBase,
 	assertValidProjectCredentials,
+	resolveCredential,
 } from '../GenericFunctions';
 
 export async function handleFile(
@@ -17,7 +18,7 @@ export async function handleFile(
 	itemIndex: number,
 ): Promise<INodeExecutionData[]> {
 	const operation = this.getNodeParameter('operation', itemIndex);
-	const credential = await this.getCredentials('gitlabExtendedApi');
+	const credential = await resolveCredential.call(this, itemIndex);
 	assertValidProjectCredentials.call(this, credential);
 
 	const base = buildProjectBase(credential);
@@ -61,8 +62,8 @@ export async function handleFile(
 	}
 
 	const response = returnAll
-		? await gitlabApiRequestAllItems.call(this, requestMethod, endpoint, body, qs)
-		: await gitlabApiRequest.call(this, requestMethod, endpoint, body, qs);
+		? await gitlabApiRequestAllItems.call(this, requestMethod, endpoint, body, qs, itemIndex)
+		: await gitlabApiRequest.call(this, requestMethod, endpoint, body, qs, {}, itemIndex);
 
 	return this.helpers.constructExecutionMetaData(
 		this.helpers.returnJsonArray(response as IDataObject),

--- a/nodes/GitlabExtended/resources/mergeRequest.ts
+++ b/nodes/GitlabExtended/resources/mergeRequest.ts
@@ -11,6 +11,7 @@ import {
 	buildProjectBase,
 	assertValidProjectCredentials,
 	addOptionalStringParam,
+	resolveCredential,
 } from '../GenericFunctions';
 import { requirePositive } from '../validators';
 
@@ -19,7 +20,7 @@ export async function handleMergeRequest(
 	itemIndex: number,
 ): Promise<INodeExecutionData[]> {
 	const operation = this.getNodeParameter('operation', itemIndex);
-	const credential = await this.getCredentials('gitlabExtendedApi');
+	const credential = await resolveCredential.call(this, itemIndex);
 	assertValidProjectCredentials.call(this, credential);
 
 	const base = buildProjectBase(credential);
@@ -306,8 +307,8 @@ export async function handleMergeRequest(
 	}
 
 	const response = returnAll
-		? await gitlabApiRequestAllItems.call(this, requestMethod, endpoint, body, qs)
-		: await gitlabApiRequest.call(this, requestMethod, endpoint, body, qs);
+		? await gitlabApiRequestAllItems.call(this, requestMethod, endpoint, body, qs, itemIndex)
+		: await gitlabApiRequest.call(this, requestMethod, endpoint, body, qs, {}, itemIndex);
 
 	return this.helpers.constructExecutionMetaData(
 		this.helpers.returnJsonArray(response as IDataObject),

--- a/nodes/GitlabExtended/resources/pipeline.ts
+++ b/nodes/GitlabExtended/resources/pipeline.ts
@@ -10,6 +10,7 @@ import {
 	gitlabApiRequestAllItems,
 	buildProjectBase,
 	assertValidProjectCredentials,
+	resolveCredential,
 } from '../GenericFunctions';
 import { requirePositive } from '../validators';
 
@@ -18,7 +19,7 @@ export async function handlePipeline(
 	itemIndex: number,
 ): Promise<INodeExecutionData[]> {
 	const operation = this.getNodeParameter('operation', itemIndex);
-	const credential = await this.getCredentials('gitlabExtendedApi');
+	const credential = await resolveCredential.call(this, itemIndex);
 	assertValidProjectCredentials.call(this, credential);
 
 	const base = buildProjectBase(credential);
@@ -73,8 +74,8 @@ export async function handlePipeline(
 	}
 
 	const response = returnAll
-		? await gitlabApiRequestAllItems.call(this, requestMethod, endpoint, body, qs)
-		: await gitlabApiRequest.call(this, requestMethod, endpoint, body, qs);
+		? await gitlabApiRequestAllItems.call(this, requestMethod, endpoint, body, qs, itemIndex)
+		: await gitlabApiRequest.call(this, requestMethod, endpoint, body, qs, {}, itemIndex);
 
 	return this.helpers.constructExecutionMetaData(
 		this.helpers.returnJsonArray(response as IDataObject),

--- a/tests/gitlabApiRequest.test.js
+++ b/tests/gitlabApiRequest.test.js
@@ -1,9 +1,9 @@
 import assert from 'node:assert';
 import test from 'node:test';
 import {
-        gitlabApiRequest,
-        gitlabApiRequestAllItems,
-        getMergeRequestDiscussion,
+	gitlabApiRequest,
+	gitlabApiRequestAllItems,
+	getMergeRequestDiscussion,
 } from '../dist/nodes/GitlabExtended/GenericFunctions.js';
 import { NodeApiError } from 'n8n-workflow/dist/errors/index.js';
 import { GitlabExtended } from '../dist/nodes/GitlabExtended/GitlabExtended.node.js';
@@ -17,8 +17,9 @@ function mockContext({
 	const calls = {};
 	return {
 		calls,
-		getNodeParameter() {
-			throw new Error('Unexpected parameter');
+		getNodeParameter(name, _idx, fallback) {
+			if (name === 'authentication') return 'credential';
+			return fallback;
 		},
 		async getCredentials(name) {
 			calls.credentials = name;
@@ -41,41 +42,41 @@ function mockContext({
 }
 
 function createNodeContext(params, cred = {}) {
-       const calls = {};
-       return {
-               calls,
-               getInputData() {
-                       return [{ json: {} }];
-               },
-               getNodeParameter(name) {
-                       return params[name];
-               },
-               async getCredentials() {
-                       return {
-                               server: 'https://gitlab.example.com',
-                               accessToken: 't',
-                               projectOwner: 'owner',
-                               projectName: 'repo',
-                               projectId: 1,
-                               ...cred,
-                       };
-               },
-               helpers: {
-                       async requestWithAuthentication(name, options) {
-                               calls.options = options;
-                               return {};
-                       },
-                       constructExecutionMetaData(data) {
-                               return data;
-                       },
-                       returnJsonArray(data) {
-                               return [{ json: data }];
-                       },
-               },
-               getNode() {
-                       return {};
-               },
-       };
+	const calls = {};
+	return {
+		calls,
+		getInputData() {
+			return [{ json: {} }];
+		},
+		getNodeParameter(name, _idx, fallback) {
+			return Object.prototype.hasOwnProperty.call(params, name) ? params[name] : fallback;
+		},
+		async getCredentials() {
+			return {
+				server: 'https://gitlab.example.com',
+				accessToken: 't',
+				projectOwner: 'owner',
+				projectName: 'repo',
+				projectId: 1,
+				...cred,
+			};
+		},
+		helpers: {
+			async requestWithAuthentication(name, options) {
+				calls.options = options;
+				return {};
+			},
+			constructExecutionMetaData(data) {
+				return data;
+			},
+			returnJsonArray(data) {
+				return [{ json: data }];
+			},
+		},
+		getNode() {
+			return {};
+		},
+	};
 }
 
 test('uses Gitlab Extended credentials and builds correct URL', async () => {
@@ -93,108 +94,141 @@ test('builds URL correctly when server lacks trailing slash', async () => {
 });
 
 test('getMergeRequestDiscussion builds correct endpoint', async () => {
-        const ctx = mockContext({ projectId: 1 });
-        const result = await getMergeRequestDiscussion.call(ctx, 1234, '123abc');
-        assert.strictEqual(
-                ctx.calls.options.uri,
-                'https://gitlab.example.com/api/v4/projects/1/merge_requests/1234/discussions/123abc',
-        );
-        assert.deepStrictEqual(result, { ok: true });
+	const ctx = mockContext({ projectId: 1 });
+	const result = await getMergeRequestDiscussion.call(ctx, 1234, '123abc');
+	assert.strictEqual(
+		ctx.calls.options.uri,
+		'https://gitlab.example.com/api/v4/projects/1/merge_requests/1234/discussions/123abc',
+	);
+	assert.deepStrictEqual(result, { ok: true });
 });
 
 test('gitlabApiRequest supports DELETE method', async () => {
-        const ctx = mockContext();
-        await gitlabApiRequest.call(
-                ctx,
-                'DELETE',
-                '/projects/1/repository/branches/foo',
-                {},
-                undefined,
-        );
-        assert.strictEqual(ctx.calls.options.method, 'DELETE');
-        assert.strictEqual(
-                ctx.calls.options.uri,
-                'https://gitlab.example.com/api/v4/projects/1/repository/branches/foo',
-        );
+	const ctx = mockContext();
+	await gitlabApiRequest.call(ctx, 'DELETE', '/projects/1/repository/branches/foo', {}, undefined);
+	assert.strictEqual(ctx.calls.options.method, 'DELETE');
+	assert.strictEqual(
+		ctx.calls.options.uri,
+		'https://gitlab.example.com/api/v4/projects/1/repository/branches/foo',
+	);
 });
 
 test('execute throws when credentials lack project info', async () => {
-       const node = new GitlabExtended();
-       const ctx = createNodeContext(
-               { resource: 'branch', operation: 'get', branch: 'main' },
-               { projectId: 0, projectOwner: '', projectName: '' },
-       );
-       await assert.rejects(
-               () => node.execute.call(ctx),
-               /Credentials must include either projectId or both projectOwner and projectName/,
-       );
+	const node = new GitlabExtended();
+	const ctx = createNodeContext(
+		{ resource: 'branch', operation: 'get', branch: 'main' },
+		{ projectId: 0, projectOwner: '', projectName: '' },
+	);
+	await assert.rejects(
+		() => node.execute.call(ctx),
+		/Credentials must include either projectId or both projectOwner and projectName/,
+	);
 });
 
 test('execute uses owner and name when projectId missing', async () => {
-        const node = new GitlabExtended();
-        const ctx = createNodeContext(
-                { resource: 'branch', operation: 'get', branch: 'main' },
-                { projectId: 0, projectOwner: 'alice', projectName: 'repo' },
-        );
-        await node.execute.call(ctx);
-        assert.strictEqual(
-                ctx.calls.options.uri,
-                'https://gitlab.example.com/api/v4/projects/alice%2Frepo/repository/branches/main',
-        );
+	const node = new GitlabExtended();
+	const ctx = createNodeContext(
+		{ resource: 'branch', operation: 'get', branch: 'main' },
+		{ projectId: 0, projectOwner: 'alice', projectName: 'repo' },
+	);
+	await node.execute.call(ctx);
+	assert.strictEqual(
+		ctx.calls.options.uri,
+		'https://gitlab.example.com/api/v4/projects/alice%2Frepo/repository/branches/main',
+	);
 });
 
 test('gitlabApiRequestAllItems follows x-next-page header', async () => {
-       const responses = [
-               { body: [{ a: 1 }], headers: { 'x-next-page': '2' } },
-               { body: [{ a: 2 }], headers: { 'x-next-page': '' } },
-       ];
-       const calls = [];
-       const ctx = {
-               calls,
-               getNodeParameter() {
-                       throw new Error('Unexpected parameter');
-               },
-               async getCredentials(name) {
-                       if (name !== 'gitlabExtendedApi') throw new Error('Unexpected credentials name');
-                       return { server: 'https://gitlab.example.com', accessToken: 't' };
-               },
-               helpers: {
-                       async requestWithAuthentication(name, options) {
-                               calls.push({ options: JSON.parse(JSON.stringify(options)) });
-                               return responses.shift();
-                       },
-               },
-               getNode() { return {}; },
-       };
+	const responses = [
+		{ body: [{ a: 1 }], headers: { 'x-next-page': '2' } },
+		{ body: [{ a: 2 }], headers: { 'x-next-page': '' } },
+	];
+	const calls = [];
+	const ctx = {
+		calls,
+		getNodeParameter(name, _i, fallback) {
+			if (name === 'authentication') return 'credential';
+			return fallback;
+		},
+		async getCredentials(name) {
+			if (name !== 'gitlabExtendedApi') throw new Error('Unexpected credentials name');
+			return { server: 'https://gitlab.example.com', accessToken: 't' };
+		},
+		helpers: {
+			async requestWithAuthentication(name, options) {
+				calls.push({ options: JSON.parse(JSON.stringify(options)) });
+				return responses.shift();
+			},
+		},
+		getNode() {
+			return {};
+		},
+	};
 
-       const result = await gitlabApiRequestAllItems.call(ctx, 'GET', '/foo', {}, {});
-       assert.deepStrictEqual(result, [{ a: 1 }, { a: 2 }]);
-       assert.strictEqual(calls.length, 2);
-       assert.strictEqual(calls[0].options.qs.page, 1);
-       assert.strictEqual(calls[1].options.qs.page, 2);
+	const result = await gitlabApiRequestAllItems.call(ctx, 'GET', '/foo', {}, {});
+	assert.deepStrictEqual(result, [{ a: 1 }, { a: 2 }]);
+	assert.strictEqual(calls.length, 2);
+	assert.strictEqual(calls[0].options.qs.page, 1);
+	assert.strictEqual(calls[1].options.qs.page, 2);
 });
 
 test('gitlabApiRequest surfaces original error message when no response body', async () => {
-       const ctx = {
-               async getCredentials(name) {
-                       if (name !== 'gitlabExtendedApi') throw new Error('Unexpected credentials name');
-                       return { server: 'https://gitlab.example.com', accessToken: 't' };
-               },
-               helpers: {
-                       async requestWithAuthentication() {
-                               const err = new Error('request failed');
-                               throw err;
-                       },
-               },
-               getNode() { return {}; },
-       };
+	const ctx = {
+		getNodeParameter(name, _i, fallback) {
+			if (name === 'authentication') return 'credential';
+			return fallback;
+		},
+		async getCredentials(name) {
+			if (name !== 'gitlabExtendedApi') throw new Error('Unexpected credentials name');
+			return { server: 'https://gitlab.example.com', accessToken: 't' };
+		},
+		helpers: {
+			async requestWithAuthentication() {
+				const err = new Error('request failed');
+				throw err;
+			},
+		},
+		getNode() {
+			return {};
+		},
+	};
 
-       await assert.rejects(
-               () => gitlabApiRequest.call(ctx, 'GET', '/foo', {}, undefined),
-               (err) => {
-                       assert(err instanceof NodeApiError);
-                       assert.match(err.message, /request failed/);
-                       return true;
-               },
-       );
+	await assert.rejects(
+		() => gitlabApiRequest.call(ctx, 'GET', '/foo', {}, undefined),
+		(err) => {
+			assert(err instanceof NodeApiError);
+			assert.match(err.message, /request failed/);
+			return true;
+		},
+	);
+});
+
+test('gitlabApiRequest uses custom credentials when selected', async () => {
+	const params = {
+		authentication: 'custom',
+		server: 'https://custom.example.com',
+		accessToken: 'abc',
+		projectId: 99,
+	};
+	const ctx = {
+		calls: {},
+		getNodeParameter(name) {
+			return params[name];
+		},
+		async getCredentials() {
+			throw new Error('should not use credentials');
+		},
+		helpers: {
+			async request(options) {
+				ctx.calls.options = options;
+				return { ok: true };
+			},
+		},
+		getNode() {
+			return {};
+		},
+	};
+
+	await gitlabApiRequest.call(ctx, 'GET', '/projects', {}, undefined, {}, 0);
+	assert.strictEqual(ctx.calls.options.uri, 'https://custom.example.com/api/v4/projects');
 });

--- a/tests/helpers/createContext.js
+++ b/tests/helpers/createContext.js
@@ -1,30 +1,34 @@
 export default function createContext(params) {
-  const calls = {};
-  return {
-    calls,
-    getInputData() {
-      return [{ json: {} }];
-    },
-    getNodeParameter(name) {
-      return params[name];
-    },
-    async getCredentials() {
-      return { server: 'https://gitlab.example.com', accessToken: 't', projectId: 1 };
-    },
-    helpers: {
-      async requestWithAuthentication(name, options) {
-        calls.options = options;
-        return {};
-      },
-      constructExecutionMetaData(data) {
-        return data;
-      },
-      returnJsonArray(data) {
-        return [{ json: data }];
-      },
-    },
-    getNode() {
-      return { parameters: params };
-    },
-  };
+	const calls = {};
+	return {
+		calls,
+		getInputData() {
+			return [{ json: {} }];
+		},
+		getNodeParameter(name, _index, fallback) {
+			return Object.prototype.hasOwnProperty.call(params, name) ? params[name] : fallback;
+		},
+		async getCredentials() {
+			return { server: 'https://gitlab.example.com', accessToken: 't', projectId: 1 };
+		},
+		helpers: {
+			async requestWithAuthentication(name, options) {
+				calls.options = options;
+				return {};
+			},
+			async request(options) {
+				calls.options = options;
+				return {};
+			},
+			constructExecutionMetaData(data) {
+				return data;
+			},
+			returnJsonArray(data) {
+				return [{ json: data }];
+			},
+		},
+		getNode() {
+			return { parameters: params };
+		},
+	};
 }


### PR DESCRIPTION
## Summary
- use `this.helpers.request` when custom authentication is selected
- record request options in tests without needing credentials
- adjust custom-auth test for new request flow

## Testing
- `npm run format:check`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6879071e51b0832ba21640248f75d26a