### PR TITLE
Add project creation and subgroup support

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ one of its operations.
 
 ### Project
 
+- `create` – Create a project
 - `get` – Get a project
 - `getAll` – List projects
 - `search` – Search projects
@@ -194,7 +195,11 @@ sending the `resolved` flag when updating a note body with `updateDiscussionNote
 | `groupId`            | Numeric group ID                                   |
 | `groupName`          | Name when creating a group                         |
 | `groupPath`          | Path when creating a group                         |
+| `parentId`           | Parent group ID when creating a subgroup          |
 | `projectId`          | Numeric project ID                                 |
+| `projectName`        | Name when creating a project                       |
+| `projectPath`        | Path when creating a project                       |
+| `namespaceId`        | Namespace for the new project                      |
 | `searchTerm`         | Term to search projects                            |
 
 ## Credentials

--- a/nodes/GitlabExtended/GitlabExtended.node.ts
+++ b/nodes/GitlabExtended/GitlabExtended.node.ts
@@ -200,6 +200,7 @@ export class GitlabExtended implements INodeType {
 				displayOptions: { show: { resource: ['project'] } },
 				description: 'Select how to manage projects',
 				options: [
+					{ name: 'Create', value: 'create', action: 'Create a project' },
 					{ name: 'Get', value: 'get', action: 'Get a project' },
 					{ name: 'Get Many', value: 'getAll', action: 'List projects' },
 					{ name: 'Search', value: 'search', action: 'Search projects' },
@@ -600,6 +601,15 @@ export class GitlabExtended implements INodeType {
 				default: '',
 			},
 			{
+				displayName: 'Parent ID',
+				name: 'parentId',
+				type: 'number',
+				typeOptions: { minValue: 1 },
+				displayOptions: { show: { resource: ['group'], operation: ['create'] } },
+				description: 'Numeric ID of the parent group',
+				default: 0,
+			},
+			{
 				displayName: 'Project ID',
 				name: 'projectId',
 				type: 'number',
@@ -617,6 +627,33 @@ export class GitlabExtended implements INodeType {
 				displayOptions: { show: { resource: ['project'], operation: ['search'] } },
 				description: 'Term to search for',
 				default: '',
+			},
+			{
+				displayName: 'Project Name',
+				name: 'projectName',
+				type: 'string',
+				required: true,
+				displayOptions: { show: { resource: ['project'], operation: ['create'] } },
+				description: 'Name of the new project',
+				default: '',
+			},
+			{
+				displayName: 'Project Path',
+				name: 'projectPath',
+				type: 'string',
+				required: true,
+				displayOptions: { show: { resource: ['project'], operation: ['create'] } },
+				description: 'URL path of the new project',
+				default: '',
+			},
+			{
+				displayName: 'Namespace ID',
+				name: 'namespaceId',
+				type: 'number',
+				typeOptions: { minValue: 1 },
+				displayOptions: { show: { resource: ['project'], operation: ['create'] } },
+				description: 'ID of the namespace for the new project',
+				default: 0,
 			},
 			{
 				displayName: 'Title',
@@ -1266,6 +1303,8 @@ export class GitlabExtended implements INodeType {
 					requestMethod = 'POST';
 					body.name = this.getNodeParameter('groupName', i);
 					body.path = this.getNodeParameter('groupPath', i);
+					const parent = this.getNodeParameter('parentId', i, 0) as number;
+					if (parent) body.parent_id = parent;
 					endpoint = `/groups`;
 				} else if (operation === 'get') {
 					requestMethod = 'GET';
@@ -1286,7 +1325,14 @@ export class GitlabExtended implements INodeType {
 					endpoint = `/groups/${id}/members`;
 				}
 			} else if (resource === 'project') {
-				if (operation === 'get') {
+				if (operation === 'create') {
+					requestMethod = 'POST';
+					body.name = this.getNodeParameter('projectName', i);
+					body.path = this.getNodeParameter('projectPath', i);
+					const ns = this.getNodeParameter('namespaceId', i, 0) as number;
+					if (ns) body.namespace_id = ns;
+					endpoint = '/projects';
+				} else if (operation === 'get') {
 					requestMethod = 'GET';
 					const id = this.getNodeParameter('projectId', i) as number;
 					requirePositive.call(this, id, 'projectId', i);

--- a/tests/groupOperations.test.js
+++ b/tests/groupOperations.test.js
@@ -19,6 +19,20 @@ test('create builds correct endpoint and body', async () => {
   assert.deepStrictEqual(ctx.calls.options.body, { name: 'Dev', path: 'dev' });
 });
 
+test('create with parentId builds correct body', async () => {
+  const node = new GitlabExtended();
+  const params = { resource: 'group', operation: 'create', groupName: 'Sub', groupPath: 'sub', parentId: 3 };
+  const ctx = createContext(params);
+  ctx.helpers.requestWithAuthentication = async (name, options) => {
+    ctx.calls.name = name;
+    ctx.calls.options = options;
+    return {};
+  };
+  await node.execute.call(ctx);
+  assert.strictEqual(ctx.calls.options.method, 'POST');
+  assert.deepStrictEqual(ctx.calls.options.body, { name: 'Sub', path: 'sub', parent_id: 3 });
+});
+
 test('get builds correct endpoint', async () => {
   const node = new GitlabExtended();
   const params = { resource: 'group', operation: 'get', groupId: 5 };

--- a/tests/projectOperations.test.js
+++ b/tests/projectOperations.test.js
@@ -26,17 +26,32 @@ test('getAll builds correct endpoint with limit', async () => {
 });
 
 test('search builds correct endpoint with query', async () => {
-	const node = new GitlabExtended();
-	const ctx = createContext({
-		resource: 'project',
-		operation: 'search',
-		searchTerm: 'test',
-		returnAll: false,
-		limit: 2,
-	});
-	await node.execute.call(ctx);
-	assert.strictEqual(ctx.calls.options.method, 'GET');
-	assert.strictEqual(ctx.calls.options.uri, 'https://gitlab.example.com/api/v4/projects');
-	assert.strictEqual(ctx.calls.options.qs.per_page, 2);
-	assert.strictEqual(ctx.calls.options.qs.search, 'test');
+        const node = new GitlabExtended();
+        const ctx = createContext({
+                resource: 'project',
+                operation: 'search',
+                searchTerm: 'test',
+                returnAll: false,
+                limit: 2,
+        });
+        await node.execute.call(ctx);
+        assert.strictEqual(ctx.calls.options.method, 'GET');
+        assert.strictEqual(ctx.calls.options.uri, 'https://gitlab.example.com/api/v4/projects');
+        assert.strictEqual(ctx.calls.options.qs.per_page, 2);
+        assert.strictEqual(ctx.calls.options.qs.search, 'test');
+});
+
+test('create builds correct endpoint and body', async () => {
+        const node = new GitlabExtended();
+        const ctx = createContext({
+                resource: 'project',
+                operation: 'create',
+                projectName: 'New',
+                projectPath: 'new',
+                namespaceId: 4,
+        });
+        await node.execute.call(ctx);
+        assert.strictEqual(ctx.calls.options.method, 'POST');
+        assert.strictEqual(ctx.calls.options.uri, 'https://gitlab.example.com/api/v4/projects');
+        assert.deepStrictEqual(ctx.calls.options.body, { name: 'New', path: 'new', namespace_id: 4 });
 });


### PR DESCRIPTION
## Summary
- allow creating subgroups via optional parentId
- add ability to create projects with optional namespace
- document new operations and parameters
- test new behaviour

## Testing
- `npm run format:check`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68791ae4c1c0832b8c05266e595832b5