### PR TITLE
added parameters to get raw diff

### DIFF
--- a/nodes/GitlabExtended/GitlabExtended.node.ts
+++ b/nodes/GitlabExtended/GitlabExtended.node.ts
@@ -739,6 +739,32 @@ export class GitlabExtended implements INodeType {
 				default: 1,
 			},
 			{
+				displayName: 'Access Raw Diffs',
+				name: 'accessRawDiffs',
+				type: 'boolean',
+				displayOptions: {
+					show: {
+						resource: ['mergeRequest'],
+						operation: ['getChanges'],
+					},
+				},
+				description: 'Whether to retrieve the raw diff for each change',
+				default: false,
+			},
+			{
+				displayName: 'Unidiff',
+				name: 'unidiff',
+				type: 'boolean',
+				displayOptions: {
+					show: {
+						resource: ['mergeRequest'],
+						operation: ['getChanges'],
+					},
+				},
+				description: 'Whether to present diffs in unified diff format',
+				default: false,
+			},
+			{
 				displayName: 'Labels',
 				name: 'labels',
 				type: 'string',

--- a/nodes/GitlabExtended/resources/mergeRequest.ts
+++ b/nodes/GitlabExtended/resources/mergeRequest.ts
@@ -204,6 +204,10 @@ export async function handleMergeRequest(
 		requestMethod = 'GET';
 		const iid = this.getNodeParameter('mergeRequestIid', itemIndex) as number;
 		requirePositive.call(this, iid, 'mergeRequestIid', itemIndex);
+		const accessRawDiffs = this.getNodeParameter('accessRawDiffs', itemIndex, false) as boolean;
+		const unidiff = this.getNodeParameter('unidiff', itemIndex, false) as boolean;
+		if (accessRawDiffs) qs.access_raw_diffs = true;
+		if (unidiff) qs.unidiff = true;
 		endpoint = `${base}/merge_requests/${iid}/changes`;
 	} else if (operation === 'getDiscussions') {
 		requestMethod = 'GET';

--- a/tests/mergeRequestOperations.test.js
+++ b/tests/mergeRequestOperations.test.js
@@ -280,6 +280,25 @@ test('getChanges builds correct endpoint', async () => {
 	);
 });
 
+test('getChanges includes query params when accessRawDiffs and unidiff are true', async () => {
+	const node = new GitlabExtended();
+	const ctx = createTrackedContext({
+		resource: 'mergeRequest',
+		operation: 'getChanges',
+		mergeRequestIid: 11,
+		accessRawDiffs: true,
+		unidiff: true,
+	});
+	await node.execute.call(ctx);
+	assert.strictEqual(ctx.calls.options.method, 'GET');
+	assert.strictEqual(
+		ctx.calls.options.uri,
+		'https://gitlab.example.com/api/v4/projects/1/merge_requests/11/changes',
+	);
+	assert.strictEqual(ctx.calls.options.qs.access_raw_diffs, true);
+	assert.strictEqual(ctx.calls.options.qs.unidiff, true);
+});
+
 test('getDiscussions builds correct endpoint with limit', async () => {
 	const node = new GitlabExtended();
 	const ctx = createTrackedContext({


### PR DESCRIPTION
## Add `access_raw_diffs` and `unidiff` query parameters to getChanges

### Why
GitLab's API **does not return diff content for large files by default**. When a merge request has large diffs, the API response omits the actual diff data unless `access_raw_diffs=true` is explicitly set.

This makes it impossible to:
- Parse diff content for automated code reviews
- Analyze changes in merge requests with large files

The `unidiff` parameter is also useful for getting diffs in unified format for better tooling compatibility.

Currently, users have to use the generic "Raw API" operation to access these parameters. This PR exposes them directly in the `getChanges` operation.

### API Reference
https://docs.gitlab.com/ee/api/merge_requests.html#get-single-mr-changes

### Testing

- Existing tests pass  

- New test added for query parameter inclusion